### PR TITLE
ChunkyPNG::Canvas not having metadata attribute...

### DIFF
--- a/lib/chunky_png/canvas/png_decoding.rb
+++ b/lib/chunky_png/canvas/png_decoding.rb
@@ -113,7 +113,7 @@ module ChunkyPNG
       # @param color_mode (see ChunkyPNG::Canvas::PNGDecoding#decode_png_pixelstream)
       # @return (see ChunkyPNG::Canvas::PNGDecoding#decode_png_pixelstream)
       def decode_png_with_adam7_interlacing(stream, width, height, color_mode)
-        canvas     = ChunkyPNG::Canvas.new(width, height)
+        canvas     = new(width, height)
         pixel_size = Color.bytesize(color_mode)
         start_pos  = 0
         for pass in 0...7 do


### PR DESCRIPTION
The latest commit contain patch to the bug where ChunkyPNG::Image.from_datastream is unable to set metadata.

It turns out that PNGDecoding#decode_png_with_adam7_interlacing performs ChunkyPNG::Canvas.new() explicitly. Changing it to just new() allows inheritance to flow properly.

Thus, image = super(ds) produces ChunkyPNG::Image instance. Which is the correct behavior.
