### PR TITLE
Png suite spec bug

### DIFF
--- a/spec/png_suite_spec.rb
+++ b/spec/png_suite_spec.rb
@@ -37,7 +37,7 @@ describe 'PNG testuite' do
       
       it "should decode #{File.basename(file)} (color mode: #{color_mode}, bit depth: #{bit_depth}) exactly the same as the reference image" do
         decoded = ChunkyPNG::Canvas.from_file(file)
-        File.open(reference, 'rb:binary') { |f| decoded.to_rgba_stream.should == f.read }
+        File.open(reference, 'rb') { |f| decoded.to_rgba_stream.should == f.read }
       end
     end
   end


### PR DESCRIPTION
I'm receiving multiple failures when running rspec on Ruby 1.8.6. Removing the `:binary` string from the `File.open()` mode seems to fix it.
