### PR TITLE
RegEx in from_data_url(string) only works with '=' padded strings

### DIFF
--- a/lib/chunky_png/canvas/data_url_importing.rb
+++ b/lib/chunky_png/canvas/data_url_importing.rb
@@ -10,7 +10,7 @@ module ChunkyPNG
       # @raise ChunkyPNG::SignatureMismatch if the provides string is not a properly
       #    formatted PNG data URL (i.e. it should start with "data:image/png;base64,")
       def from_data_url(string)
-        if string =~ %r[^data:image/png;base64,((?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=))$]
+        if string =~ %r[^data:image/png;base64,((?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?)$]
           from_blob($1.unpack('m').first)
         else
           raise SignatureMismatch, "The string was not a properly formatted data URL for a PNG image."


### PR DESCRIPTION
The RegEx in DataUrlImporting.from_data_url only allows strings that end with either "=" or "==", but base64 can end with other characters as well:
http://en.wikipedia.org/wiki/Base64#Padding

Thanks for the gem! :)
