### PR TITLE
Fix for case-related problem when requiring chunky_png/rmagick

### DIFF
--- a/lib/chunky_png/rmagick.rb
+++ b/lib/chunky_png/rmagick.rb
@@ -1,4 +1,4 @@
-require 'rmagick'
+require 'RMagick'
 
 module ChunkyPNG
   


### PR DESCRIPTION
Encountered a problem when requiring 'chunky_png/rmagick'.

When requiring the "rmagick" gem, lowercase is used. This probably works for case-insensitive systems, but found trouble under linux since the correct name for the gem is 'RMagick'.

Hope it helps.

Thanks for the gem! 
