### PR TITLE
Better error messages when cropping too big slices

### DIFF
--- a/lib/chunky_png/canvas/operations.rb
+++ b/lib/chunky_png/canvas/operations.rb
@@ -153,9 +153,8 @@ module ChunkyPNG
       # @raise [ChunkyPNG::OutOfBounds] when the crop dimensions plus the given coordinates 
       #     are bigger then the original image.      
       def crop!(x, y, crop_width, crop_height)
-        
-        raise ChunkyPNG::OutOfBounds, "Image width is too small!" if crop_width + x > width
-        raise ChunkyPNG::OutOfBounds, "Image width is too small!" if crop_height + y > height
+        raise ChunkyPNG::OutOfBounds, "Original image width is too small!" if crop_width + x > width
+        raise ChunkyPNG::OutOfBounds, "Original image height is too small!" if crop_height + y > height
         
         new_pixels = []
         for cy in 0...crop_height do


### PR DESCRIPTION
Hi. Cropping slices that were vertically too big made `chunky_png` complain that `Image width is too small!`, when it's actually the height that is too small. I also think it's better to explicitly say that it's the original image that is too small, not the slice - when I saw those exceptions, my first idea was "Hey, I must be putting negative numbers into the third or fourth argument".
