### PR TITLE
Fix a few off-by-one errors

### DIFF
--- a/lib/chunky_png/canvas/operations.rb
+++ b/lib/chunky_png/canvas/operations.rb
@@ -316,7 +316,7 @@ module ChunkyPNG
         y1 = [*0...height].index  { |r|    row(r).uniq != [border] }
         y2 = [*0...height].rindex { |r|    row(r).uniq != [border] }
         
-        crop! x1, y1, x2 - x1, y2 - y1
+        crop! x1, y1, x2 - x1 + 1, y2 - y1 + 1
       end
       
       protected

--- a/spec/chunky_png/canvas/operations_spec.rb
+++ b/spec/chunky_png/canvas/operations_spec.rb
@@ -312,7 +312,7 @@ end
 
 describe ChunkyPNG::Canvas::Operations do
 
-  subject { ChunkyPNG::Canvas.new(4, 4).rect(1, 1, 3, 3, 255, 255) }
+  subject { ChunkyPNG::Canvas.new(4, 4).rect(1, 1, 2, 2, 255, 255) }
 
   describe "#trim" do
     it "should trim the border" do


### PR DESCRIPTION
Hey again, Willem. I thought I'd correctly interpreted ChunkyPNG's control point semantics for rectangles and cropping, but apparently not. I was tinkering with adding border functionality and realized my mistake. These minor edits should fix the problem.
