### PR TITLE
Improve some formatting

### DIFF
--- a/lib/chunky_png/canvas.rb
+++ b/lib/chunky_png/canvas.rb
@@ -11,7 +11,6 @@ require 'chunky_png/canvas/resampling'
 require 'chunky_png/canvas/masking'
 
 module ChunkyPNG
-
   # The ChunkyPNG::Canvas class represents a raster image as a matrix of
   # pixels.
   #
@@ -32,7 +31,6 @@ module ChunkyPNG
   # the whole canvas, like cropping and alpha compositing. Simple drawing
   # functions are imported from the {ChunkyPNG::Canvas::Drawing} module.
   class Canvas
-
     include PNGEncoding
     extend  PNGDecoding
     extend  Adam7Interlacing
@@ -55,7 +53,7 @@ module ChunkyPNG
     attr_reader :height
 
     # @return [Array<ChunkyPNG::Color>] The list of pixels in this canvas.
-    #     This array always should have +width * height+ elements.
+    #   This array always should have +width * height+ elements.
     attr_reader :pixels
 
 
@@ -68,26 +66,28 @@ module ChunkyPNG
     # @overload initialize(width, height, background_color)
     #   @param [Integer] width The width in pixels of this canvas
     #   @param [Integer] height The height in pixels of this canvas
-    #   @param [Integer, ...] background_color The initial background color of this canvas.
-    #      This can be a color value or any value that {ChunkyPNG::Color.parse} can handle.
+    #   @param [Integer, ...] background_color The initial background color of
+    #     this canvas. This can be a color value or any value that
+    #     {ChunkyPNG::Color.parse} can handle.
     #
     # @overload initialize(width, height, initial)
     #   @param [Integer] width The width in pixels of this canvas
     #   @param [Integer] height The height in pixels of this canvas
-    #   @param [Array<Integer>] initial The initial pizel values. Must be an array with 
-    #     <tt>width * height</tt> elements.
+    #   @param [Array<Integer>] initial The initial pizel values. Must be an
+    #     array with <tt>width * height</tt> elements.
     def initialize(width, height, initial = ChunkyPNG::Color::TRANSPARENT)
-
       @width, @height = width, height
 
       if initial.kind_of?(Array)
-        raise ArgumentError, "The initial array should have #{width}x#{height} = #{width*height} elements!" unless initial.length == width * height
+        unless initial.length == width * height
+          raise ArgumentError, "The initial array should have #{width}x#{height} = #{width*height} elements!"
+        end
         @pixels = initial
       else
         @pixels = Array.new(width * height, ChunkyPNG::Color.parse(initial))
       end
     end
-    
+
     # Initializes a new Canvas instances when being cloned.
     # @param [ChunkyPNG::Canvas] other The canvas to duplicate
     # @return [void]
@@ -101,7 +101,7 @@ module ChunkyPNG
     # @param [ChunkyPNG::Canvas] canvas The canvas to duplicate
     # @return [ChunkyPNG::Canvas] The newly constructed canvas instance.
     def self.from_canvas(canvas)
-      self.new(canvas.width, canvas.height, canvas.pixels.dup)
+      new(canvas.width, canvas.height, canvas.pixels.dup)
     end
 
 
@@ -110,11 +110,12 @@ module ChunkyPNG
     #################################################################
 
     # Returns the dimension (width x height) for this canvas.
-    # @return [ChunkyPNG::Dimension] A dimension instance with the width and height set for this canvas.
+    # @return [ChunkyPNG::Dimension] A dimension instance with the width and
+    #   height set for this canvas.
     def dimension
       ChunkyPNG::Dimension.new(width, height)
     end
-    
+
     # Returns the area of this canvas in number of pixels.
     # @return [Integer] The number of pixels in this canvas
     def area
@@ -125,8 +126,10 @@ module ChunkyPNG
     # @param [Integer] x The x-coordinate of the pixel (column)
     # @param [Integer] y The y-coordinate of the pixel (row)
     # @param [Integer] color The new color for the provided coordinates.
-    # @return [Integer] The new color value for this pixel, i.e. <tt>color</tt>. 
-    # @raise [ChunkyPNG::OutOfBounds] when the coordinates are outside of the image's dimensions.
+    # @return [Integer] The new color value for this pixel, i.e.
+    #   <tt>color</tt>.
+    # @raise [ChunkyPNG::OutOfBounds] when the coordinates are outside of the
+    #   image's dimensions.
     # @see #set_pixel
     def []=(x, y, color)
       assert_xy!(x, y)
@@ -135,25 +138,26 @@ module ChunkyPNG
 
     # Replaces a single pixel in this canvas, without bounds checking.
     #
-    # This method return value and effects are undefined for coordinates 
+    # This method return value and effects are undefined for coordinates
     # out of bounds of the canvas.
     #
     # @param [Integer] x The x-coordinate of the pixel (column)
     # @param [Integer] y The y-coordinate of the pixel (row)
     # @param [Integer] pixel The new color for the provided coordinates.
-    # @return [Integer] The new color value for this pixel, i.e. <tt>color</tt>. 
+    # @return [Integer] The new color value for this pixel, i.e.
+    #   <tt>color</tt>.
     def set_pixel(x, y, color)
       @pixels[y * width + x] = color
     end
-   
+
     # Replaces a single pixel in this canvas, with bounds checking. It will do
     # noting if the provided coordinates are out of bounds.
     #
     # @param [Integer] x The x-coordinate of the pixel (column)
     # @param [Integer] y The y-coordinate of the pixel (row)
     # @param [Integer] pixel The new color value for the provided coordinates.
-    # @return [Integer] The new color value for this pixel, i.e. <tt>color</tt>, or 
-    #    <tt>nil</tt> if the coordinates are out of bounds.
+    # @return [Integer] The new color value for this pixel, i.e.
+    #   <tt>color</tt>, or <tt>nil</tt> if the coordinates are out of bounds.
     def set_pixel_if_within_bounds(x, y, color)
       return unless include_xy?(x, y)
       @pixels[y * width + x] = color
@@ -163,15 +167,18 @@ module ChunkyPNG
     # @param [Integer] x The x-coordinate of the pixel (column)
     # @param [Integer] y The y-coordinate of the pixel (row)
     # @return [Integer] The current color value at the provided coordinates.
-    # @raise [ChunkyPNG::OutOfBounds] when the coordinates are outside of the image's dimensions.
+    # @raise [ChunkyPNG::OutOfBounds] when the coordinates are outside of the
+    #   image's dimensions.
     # @see #get_pixel
     def [](x, y)
       assert_xy!(x, y)
       @pixels[y * width + x]
     end
 
-    # Returns a single pixel from this canvas, without checking bounds. The return value for
-    # this method is undefined if the coordinates are out of bounds.
+    # Returns a single pixel from this canvas, without checking bounds. The
+    # return value for this method is undefined if the coordinates are out of
+    # bounds.
+    #
     # @param (see #[])
     # @return [Integer] The current pixel at the provided coordinates.
     def get_pixel(x, y)
@@ -196,7 +203,8 @@ module ChunkyPNG
 
     # Replaces a row of pixels on this canvas.
     # @param [Integer] y The 0-based row index.
-    # @param [Array<Integer>] vector The vector of pixels to replace the row with.
+    # @param [Array<Integer>] vector The vector of pixels to replace the row
+    #   with.
     # @return [void]
     def replace_row!(y, vector)
       assert_y!(y) && assert_width!(vector.length)
@@ -205,7 +213,8 @@ module ChunkyPNG
 
     # Replaces a column of pixels on this canvas.
     # @param [Integer] x The 0-based column index.
-    # @param [Array<Integer>] vector The vector of pixels to replace the column with.
+    # @param [Array<Integer>] vector The vector of pixels to replace the column
+    #   with.
     # @return [void]
     def replace_column!(x, vector)
       assert_x!(x) && assert_height!(vector.length)
@@ -215,49 +224,55 @@ module ChunkyPNG
     end
 
     # Checks whether the given coordinates are in the range of the canvas
-    # @param [ChunkyPNG::Point, Array, Hash, String] point_like The point to check.
-    # @return [true, false] True if the x and y coordinates of the point are  
-    #    within the limits of this canvas.
+    # @param [ChunkyPNG::Point, Array, Hash, String] point_like The point to
+    #   check.
+    # @return [true, false] True if the x and y coordinates of the point are
+    #   within the limits of this canvas.
     # @see ChunkyPNG.Point
     def include_point?(*point_like)
       dimension.include?(ChunkyPNG::Point(*point_like))
     end
-    
+
     alias_method :include?,    :include_point?
-    
-    # Checks whether the given x- and y-coordinate are in the range of the canvas
+
+    # Checks whether the given x- and y-coordinate are in the range of the
+    # canvas
+    #
     # @param [Integer] x The x-coordinate of the pixel (column)
     # @param [Integer] y The y-coordinate of the pixel (row)
-    # @return [true, false] True if the x- and y-coordinate is in the range of this canvas.
+    # @return [true, false] True if the x- and y-coordinate is in the range of
+    #   this canvas.
     def include_xy?(x, y)
       y >= 0 && y < height && x >= 0 && x < width
     end
-    
+
     # Checks whether the given y-coordinate is in the range of the canvas
     # @param [Integer] y The y-coordinate of the pixel (row)
-    # @return [true, false] True if the y-coordinate is in the range of this canvas.
+    # @return [true, false] True if the y-coordinate is in the range of this
+    #   canvas.
     def include_y?(y)
       y >= 0 && y < height
     end
 
     # Checks whether the given x-coordinate is in the range of the canvas
     # @param [Integer] x The y-coordinate of the pixel (column)
-    # @return [true, false] True if the x-coordinate is in the range of this canvas.
+    # @return [true, false] True if the x-coordinate is in the range of this
+    #   canvas.
     def include_x?(x)
       x >= 0 && x < width
     end
 
     # Returns the palette used for this canvas.
-    # @return [ChunkyPNG::Palette] A palette which contains all the colors that are
-    #    being used for this image.
+    # @return [ChunkyPNG::Palette] A palette which contains all the colors that
+    #   are being used for this image.
     def palette
       ChunkyPNG::Palette.from_canvas(self)
     end
 
     # Equality check to compare this canvas with other matrices.
     # @param other The object to compare this Matrix to.
-    # @return [true, false] True if the size and pixel values of the other canvas
-    #    are exactly the same as this canvas's size and pixel values.
+    # @return [true, false] True if the size and pixel values of the other
+    #   canvas are exactly the same as this canvas's size and pixel values.
     def eql?(other)
       other.kind_of?(self.class) && other.pixels == self.pixels &&
             other.width == self.width && other.height == self.height
@@ -274,7 +289,7 @@ module ChunkyPNG
     def to_image
       ChunkyPNG::Image.from_canvas(self)
     end
-    
+
     # Alternative implementation of the inspect method.
     # @return [String] A nicely formatted string representation of this canvas.
     # @private
@@ -285,51 +300,73 @@ module ChunkyPNG
       end
       inspected << "\n]>"
     end
-    
+
     protected
-    
+
     # Replaces the image, given a new width, new height, and a new pixel array.
     def replace_canvas!(new_width, new_height, new_pixels)
-      raise ArgumentError, "The provided pixel array should have #{new_width * new_height} items" unless new_pixels.length == new_width * new_height
+      unless new_pixels.length == new_width * new_height
+        raise ArgumentError, "The provided pixel array should have #{new_width * new_height} items"
+      end
       @width, @height, @pixels = new_width, new_height, new_pixels
-      return self
+      self
     end
-    
+
     # Throws an exception if the x-coordinate is out of bounds.
     def assert_x!(x)
-      raise ChunkyPNG::OutOfBounds, "Column index #{x} out of bounds!" unless include_x?(x)
-      return true
+      unless include_x?(x)
+        raise ChunkyPNG::OutOfBounds, "Column index #{x} out of bounds!"
+      end
+      true
     end
-    
+
     # Throws an exception if the y-coordinate is out of bounds.
     def assert_y!(y)
-      raise ChunkyPNG::OutOfBounds, "Row index #{y} out of bounds!" unless include_y?(y)
-      return true
+      unless include_y?(y)
+        raise ChunkyPNG::OutOfBounds, "Row index #{y} out of bounds!"
+      end
+      true
     end
-    
+
     # Throws an exception if the x- or y-coordinate is out of bounds.
     def assert_xy!(x, y)
-      raise ChunkyPNG::OutOfBounds, "Coordinates (#{x},#{y}) out of bounds!" unless include_xy?(x, y)
-      return true
+      unless include_xy?(x, y)
+        raise ChunkyPNG::OutOfBounds, "Coordinates (#{x},#{y}) out of bounds!"
+      end
+      true
     end
 
-    # Throws an exception if the vector_length does not match this canvas' height.
+    # Throws an exception if the vector_length does not match this canvas'
+    # height.
     def assert_height!(vector_length)
-      raise ChunkyPNG::ExpectationFailed, "The length of the vector (#{vector_length}) does not match the canvas height (#{height})!" if height != vector_length
-      return true
+      if height != vector_length
+        raise ChunkyPNG::ExpectationFailed,
+          "The length of the vector (#{vector_length}) does not match the canvas height (#{height})!"
+      end
+      true
     end
 
-    # Throws an exception if the vector_length does not match this canvas' width.
+    # Throws an exception if the vector_length does not match this canvas'
+    # width.
     def assert_width!(vector_length)
-      raise ChunkyPNG::ExpectationFailed, "The length of the vector (#{vector_length}) does not match the canvas width (#{width})!" if width != vector_length
-      return true
+      if width != vector_length
+        raise ChunkyPNG::ExpectationFailed,
+          "The length of the vector (#{vector_length}) does not match the canvas width (#{width})!"
+      end
+      true
     end
 
     # Throws an exception if the matrix width and height does not match this canvas' dimensions.
     def assert_size!(matrix_width, matrix_height)
-      raise ChunkyPNG::ExpectationFailed, "The width of the matrix does not match the canvas width!"   if width  != matrix_width
-      raise ChunkyPNG::ExpectationFailed, "The height of the matrix does not match the canvas height!" if height != matrix_height
-      return true
+      if width  != matrix_width
+        raise ChunkyPNG::ExpectationFailed,
+          'The width of the matrix does not match the canvas width!'
+      end
+      if height != matrix_height
+        raise ChunkyPNG::ExpectationFailed,
+          'The height of the matrix does not match the canvas height!'
+      end
+      true
     end
   end
 end

--- a/lib/chunky_png/canvas/drawing.rb
+++ b/lib/chunky_png/canvas/drawing.rb
@@ -1,17 +1,19 @@
 module ChunkyPNG
   class Canvas
-    
+
     # Module that adds some primitive drawing methods to {ChunkyPNG::Canvas}.
     #
-    # All of these methods change the current canvas instance and do not create a new one,
-    # even though the method names do not end with a bang.
+    # All of these methods change the current canvas instance and do not create
+    # a new one, even though the method names do not end with a bang.
     #
-    # @note Drawing operations will not fail when something is drawn outside of the bounds
-    #       of the canvas; these pixels will simply be ignored.
+    # @note Drawing operations will not fail when something is drawn outside of
+    #   the bounds of the canvas; these pixels will simply be ignored.
     # @see ChunkyPNG::Canvas
     module Drawing
-      
-      # Composes a pixel on the canvas by alpha blending a color with its background color.
+
+      # Composes a pixel on the canvas by alpha blending a color with its
+      # background color.
+      #
       # @param [Integer] x The x-coordinate of the pixel to blend.
       # @param [Integer] y The y-coordinate of the pixel to blend.
       # @param [Integer] color The foreground color to blend with
@@ -20,49 +22,49 @@ module ChunkyPNG
         return unless include_xy?(x, y)
         compose_pixel_unsafe(x, y, ChunkyPNG::Color.parse(color))
       end
-      
-      # Composes a pixel on the canvas by alpha blending a color with its background color,
-      # without bounds checking.
+
+      # Composes a pixel on the canvas by alpha blending a color with its
+      # background color, without bounds checking.
+      #
       # @param (see #compose_pixel)
       # @return [Integer] The composed color.
       def compose_pixel_unsafe(x, y, color)
         set_pixel(x, y, ChunkyPNG::Color.compose(color, get_pixel(x, y)))
       end
-      
+
       # Draws a Bezier curve
       # @param [Array, Point] A collection of control points
       # @return [Chunky:PNG::Canvas] Itself, with the curve drawn
       def bezier_curve(points, stroke_color = ChunkyPNG::Color::BLACK)
-        
         points = ChunkyPNG::Vector(*points)
         case points.length
           when 0, 1; return self
           when 2; return line(points[0].x, points[0].y, points[1].x, points[1].y, stroke_color)
         end
-        
+
         curve_points = Array.new
-        
-        t = 0
-        n = points.length - 1
+
+        t     = 0
+        n     = points.length - 1
         bicof = 0
-        
+
         while t <= 100
           cur_p = ChunkyPNG::Point.new(0,0)
-          
+
           # Generate a float of t.
           t_f = t / 100.00
-          
+
           cur_p.x += ((1 - t_f) ** n) * points[0].x
           cur_p.y += ((1 - t_f) ** n) * points[0].y
-          
+
           for i in 1...points.length - 1
             bicof = binomial_coefficient(n , i)
-            
-            cur_p.x += (bicof * (1 - t_f) ** (n - i)) *  (t_f ** i) * points[i].x 
-            cur_p.y += (bicof * (1 - t_f) ** (n - i)) *  (t_f ** i) * points[i].y 
+
+            cur_p.x += (bicof * (1 - t_f) ** (n - i)) *  (t_f ** i) * points[i].x
+            cur_p.y += (bicof * (1 - t_f) ** (n - i)) *  (t_f ** i) * points[i].y
             i += 1
           end
-          
+
           cur_p.x += (t_f ** n) * points[n].x
           cur_p.y += (t_f ** n) * points[n].y
 
@@ -76,10 +78,9 @@ module ChunkyPNG
           line_xiaolin_wu(p1.x.round, p1.y.round, p2.x.round, p2.y.round, stroke_color)
         end
 
-        return self
+        self
       end
-      
-      
+
       # Draws an anti-aliased line using Xiaolin Wu's algorithm.
       #
       # @param [Integer] x0 The x-coordinate of the first control point.
@@ -87,81 +88,93 @@ module ChunkyPNG
       # @param [Integer] x1 The x-coordinate of the second control point.
       # @param [Integer] y1 The y-coordinate of the second control point.
       # @param [Integer] stroke_color The color to use for this line.
-      # @param [true, false] inclusive Whether to draw the last pixel. 
-      #    Set to false when drawing multiple lines in a path.
+      # @param [true, false] inclusive Whether to draw the last pixel. Set to
+      #   false when drawing multiple lines in a path.
       # @return [ChunkyPNG::Canvas] Itself, with the line drawn.
       def line_xiaolin_wu(x0, y0, x1, y1, stroke_color, inclusive = true)
-        
         stroke_color = ChunkyPNG::Color.parse(stroke_color)
-        
+
         dx = x1 - x0
         sx = dx < 0 ? -1 : 1
         dx *= sx
         dy = y1 - y0
         sy = dy < 0 ? -1 : 1
         dy *= sy
-        
+
         if dy == 0 # vertical line
           x0.step(inclusive ? x1 : x1 - sx, sx) do |x|
             compose_pixel(x, y0, stroke_color)
           end
-          
+
         elsif dx == 0 # horizontal line
           y0.step(inclusive ? y1 : y1 - sy, sy) do |y|
             compose_pixel(x0, y, stroke_color)
           end
-          
+
         elsif dx == dy # diagonal
           x0.step(inclusive ? x1 : x1 - sx, sx) do |x|
             compose_pixel(x, y0, stroke_color)
             y0 += sy
           end
-          
+
         elsif dy > dx  # vertical displacement
           compose_pixel(x0, y0, stroke_color)
           e_acc = 0
           e = ((dx << 16) / dy.to_f).round
           (dy - 1).downto(0) do |i|
             e_acc_temp, e_acc = e_acc, (e_acc + e) & 0xffff
-            x0 += sx if (e_acc <= e_acc_temp)
+            x0 += sx if e_acc <= e_acc_temp
             w = 0xff - (e_acc >> 8)
             compose_pixel(x0, y0, ChunkyPNG::Color.fade(stroke_color, w))
-            compose_pixel(x0 + sx, y0 + sy, ChunkyPNG::Color.fade(stroke_color, 0xff - w)) if inclusive || i > 0
+            if inclusive || i > 0
+              compose_pixel(x0 + sx,
+                            y0 + sy,
+                            ChunkyPNG::Color.fade(stroke_color, 0xff - w))
+            end
             y0 += sy
           end
           compose_pixel(x1, y1, stroke_color) if inclusive
-          
+
         else # horizontal displacement
           compose_pixel(x0, y0, stroke_color)
           e_acc = 0
           e = ((dy << 16) / dx.to_f).round
           (dx - 1).downto(0) do |i|
             e_acc_temp, e_acc = e_acc, (e_acc + e) & 0xffff
-            y0 += sy if (e_acc <= e_acc_temp)
+            y0 += sy if e_acc <= e_acc_temp
             w = 0xff - (e_acc >> 8)
             compose_pixel(x0, y0, ChunkyPNG::Color.fade(stroke_color, w))
-            compose_pixel(x0 + sx, y0 + sy, ChunkyPNG::Color.fade(stroke_color, 0xff - w)) if inclusive || i > 0
+            if inclusive || i > 0
+              compose_pixel(x0 + sx,
+                            y0 + sy,
+                            ChunkyPNG::Color.fade(stroke_color, 0xff - w))
+            end
             x0 += sx
           end
           compose_pixel(x1, y1, stroke_color) if inclusive
         end
-        
-        return self
+
+        self
       end
-      
+
       alias_method :line, :line_xiaolin_wu
-      
-      
-      # Draws a polygon on the canvas using the stroke_color, filled using the fill_color if any.
+
+      # Draws a polygon on the canvas using the stroke_color, filled using the
+      # fill_color if any.
       #
-      # @param [Array, String] The control point vector. Accepts everything {ChunkyPNG.Vector} accepts.
+      # @param [Array, String] The control point vector. Accepts everything
+      #   {ChunkyPNG.Vector} accepts.
       # @param [Integer] stroke_color The stroke color to use for this polygon.
       # @param [Integer] fill_color The fill color to use for this polygon.
       # @return [ChunkyPNG::Canvas] Itself, with the polygon drawn.
-      def polygon(path, stroke_color = ChunkyPNG::Color::BLACK, fill_color = ChunkyPNG::Color::TRANSPARENT)
-        
+      def polygon(path,
+                  stroke_color = ChunkyPNG::Color::BLACK,
+                  fill_color   = ChunkyPNG::Color::TRANSPARENT)
+
         vector = ChunkyPNG::Vector(*path)
-        raise ArgumentError, "A polygon requires at least 3 points" if path.length < 3
+        if path.length < 3
+          raise ArgumentError, 'A polygon requires at least 3 points'
+        end
 
         stroke_color = ChunkyPNG::Color.parse(stroke_color)
         fill_color   = ChunkyPNG::Color.parse(fill_color)
@@ -184,15 +197,15 @@ module ChunkyPNG
             end
           end
         end
-        
+
         # Stroke
         vector.each_edge do |(from_x, from_y), (to_x, to_y)|
           line(from_x, from_y, to_x, to_y, stroke_color, false)
         end
 
-        return self
+        self
       end
-      
+
       # Draws a rectangle on the canvas, using two control points.
       #
       # @param [Integer] x0 The x-coordinate of the first control point.
@@ -202,11 +215,13 @@ module ChunkyPNG
       # @param [Integer] stroke_color The line color to use for this rectangle.
       # @param [Integer] fill_color The fill color to use for this rectangle.
       # @return [ChunkyPNG::Canvas] Itself, with the rectangle drawn.
-      def rect(x0, y0, x1, y1, stroke_color = ChunkyPNG::Color::BLACK, fill_color = ChunkyPNG::Color::TRANSPARENT)
-      
+      def rect(x0, y0, x1, y1,
+               stroke_color = ChunkyPNG::Color::BLACK,
+               fill_color   = ChunkyPNG::Color::TRANSPARENT)
+
         stroke_color = ChunkyPNG::Color.parse(stroke_color)
         fill_color   = ChunkyPNG::Color.parse(fill_color)
-      
+
         # Fill
         unless fill_color == ChunkyPNG::Color::TRANSPARENT
           [x0, x1].min.upto([x0, x1].max) do |x|
@@ -215,16 +230,16 @@ module ChunkyPNG
             end
           end
         end
-        
+
         # Stroke
         line(x0, y0, x0, y1, stroke_color, false)
         line(x0, y1, x1, y1, stroke_color, false)
         line(x1, y1, x1, y0, stroke_color, false)
         line(x1, y0, x0, y0, stroke_color, false)
-        
-        return self
+
+        self
       end
-      
+
       # Draws a circle on the canvas.
       #
       # @param [Integer] x0 The x-coordinate of the center of the circle.
@@ -233,7 +248,9 @@ module ChunkyPNG
       # @param [Integer] stroke_color The color to use for the line.
       # @param [Integer] fill_color The color to use that fills the circle.
       # @return [ChunkyPNG::Canvas] Itself, with the circle drawn.
-      def circle(x0, y0, radius, stroke_color = ChunkyPNG::Color::BLACK, fill_color = ChunkyPNG::Color::TRANSPARENT)
+      def circle(x0, y0, radius,
+                 stroke_color = ChunkyPNG::Color::BLACK,
+                 fill_color   = ChunkyPNG::Color::TRANSPARENT)
 
         stroke_color = ChunkyPNG::Color.parse(stroke_color)
         fill_color   = ChunkyPNG::Color.parse(fill_color)
@@ -283,20 +300,26 @@ module ChunkyPNG
 
         unless fill_color == ChunkyPNG::Color::TRANSPARENT
           lines.each_with_index do |length, y|
-            line(x0 - length, y0 - y, x0 + length, y0 - y, fill_color) if length > 0
-            line(x0 - length, y0 + y, x0 + length, y0 + y, fill_color) if length > 0 && y > 0
+            if length > 0
+              line(x0 - length, y0 - y, x0 + length, y0 - y, fill_color)
+            end
+            if length > 0 && y > 0
+              line(x0 - length, y0 + y, x0 + length, y0 + y, fill_color)
+            end
           end
         end
 
-        return self
+        self
       end
-      
+
       private
-      
+
       # Calculates the binomial coefficient for n over k.
       #
-      # @param [Integer] n first parameter in coeffient (the number on top when looking at the mathematic formula)
-      # @param [Integer] k k-element, second parameter in coeffient (the number on the bottom when looking at the mathematic formula)
+      # @param [Integer] n first parameter in coeffient (the number on top when
+      #   looking at the mathematic formula)
+      # @param [Integer] k k-element, second parameter in coeffient (the number
+      #   on the bottom when looking at the mathematic formula)
       # @return [Integer] The binomial coeffcient of (n,k)
       def binomial_coefficient(n, k)
         return  1 if n == k || k == 0

--- a/lib/chunky_png/canvas/operations.rb
+++ b/lib/chunky_png/canvas/operations.rb
@@ -1,54 +1,54 @@
 module ChunkyPNG
   class Canvas
-    
-    # The ChunkyPNG::Canvas::Operations module defines methods to perform operations
-    # on a {ChunkyPNG::Canvas}. The module is included into the Canvas class so all
-    # these methods are available on every canvas.
+    # The ChunkyPNG::Canvas::Operations module defines methods to perform
+    # operations on a {ChunkyPNG::Canvas}. The module is included into the
+    # Canvas class so all these methods are available on every canvas.
     #
-    # Note that some of these operations modify the canvas, while some operations return 
-    # a new canvas and leave the original intact.
+    # Note that some of these operations modify the canvas, while some
+    # operations return a new canvas and leave the original intact.
     #
     # @see ChunkyPNG::Canvas
     module Operations
-      
-      # Converts the canvas to grascale.
+      # Converts the canvas to grayscale.
       #
-      # This method will modify the canvas. The obtain a new canvas and leave the 
-      # current instance intact, use {#grayscale} instead.
+      # This method will modify the canvas. The obtain a new canvas and leave
+      # the current instance intact, use {#grayscale} instead.
       #
       # @return [ChunkyPNG::Canvas] Returns itself, converted to grayscale.
       # @see {#grayscale}
       # @see {ChunkyPNG::Color#to_grayscale}
       def grayscale!
         pixels.map! { |pixel| ChunkyPNG::Color.to_grayscale(pixel) }
-        return self
+        self
       end
 
-      # Converts the canvas to grascale, returning a new canvas.
+      # Converts the canvas to grayscale, returning a new canvas.
       #
       # This method will not modify the canvas. To modift the current canvas,
       # use {#grayscale!} instead.
       #
-      # @return [ChunkyPNG::Canvas] A copy of the canvas, converted to grasycale.
+      # @return [ChunkyPNG::Canvas] A copy of the canvas, converted to
+      #   grayscale.
       # @see {#grayscale!}
       # @see {ChunkyPNG::Color#to_grayscale}
       def grayscale
         dup.grayscale!
       end
-      
-      # Composes another image onto this image using alpha blending. This will modify
-      # the current canvas.
+
+      # Composes another image onto this image using alpha blending. This will
+      # modify the current canvas.
       #
-      # If you simply want to replace pixels or when the other image does not have
-      # transparency, it is faster to use {#replace!}.
+      # If you simply want to replace pixels or when the other image does not
+      # have transparency, it is faster to use {#replace!}.
       #
-      # @param [ChunkyPNG::Canvas] other The foreground canvas to compose on the
-      #     current canvas, using alpha compositing.
+      # @param [ChunkyPNG::Canvas] other The foreground canvas to compose on
+      #   the current canvas, using alpha compositing.
       # @param [Integer] offset_x The x-offset to apply the new foreground on.
       # @param [Integer] offset_y The y-offset to apply the new foreground on.
-      # @return [ChunkyPNG::Canvas] Returns itself, but with the other canvas composed onto it.
-      # @raise [ChunkyPNG::OutOfBounds] when the other canvas doesn't fit on this one,
-      #     given the offset and size of the other canvas.
+      # @return [ChunkyPNG::Canvas] Returns itself, but with the other canvas
+      #   composed onto it.
+      # @raise [ChunkyPNG::OutOfBounds] when the other canvas doesn't fit on
+      #   this one, given the offset and size of the other canvas.
       # @see #replace!
       # @see #compose
       def compose!(other, offset_x = 0, offset_y = 0)
@@ -56,43 +56,51 @@ module ChunkyPNG
 
         for y in 0...other.height do
           for x in 0...other.width do
-            set_pixel(x + offset_x, y + offset_y, ChunkyPNG::Color.compose(other.get_pixel(x, y), get_pixel(x + offset_x, y + offset_y)))
+            set_pixel(x + offset_x,
+                      y + offset_y,
+                      ChunkyPNG::Color.compose(other.get_pixel(x, y),
+                                               get_pixel(x + offset_x,
+                                                         y + offset_y)))
           end
         end
         self
       end
-      
-      # Composes another image onto this image using alpha blending. This will return
-      # a new canvas and leave the original intact.
+
+      # Composes another image onto this image using alpha blending. This will
+      # return a new canvas and leave the original intact.
       #
-      # If you simply want to replace pixels or when the other image does not have
-      # transparency, it is faster to use {#replace}.
+      # If you simply want to replace pixels or when the other image does not
+      # have transparency, it is faster to use {#replace}.
       #
       # @param (see #compose!)
-      # @return [ChunkyPNG::Canvas] Returns the new canvas, composed of the other 2.
-      # @raise [ChunkyPNG::OutOfBounds] when the other canvas doesn't fit on this one,
-      #     given the offset and size of the other canvas.
+      # @return [ChunkyPNG::Canvas] Returns the new canvas, composed of the
+      #   other 2.
+      # @raise [ChunkyPNG::OutOfBounds] when the other canvas doesn't fit on
+      #   this one, given the offset and size of the other canvas.
       #
-      # @note API changed since 1.0 - This method now no longer is in place, but returns
-      #     a new canvas and leaves the original intact. Use {#compose!} if you want to
-      #     compose on the canvas in place.
+      # @note API changed since 1.0 - This method now no longer is in place,
+      #   but returns a new canvas and leaves the original intact. Use
+      #   {#compose!} if you want to compose on the canvas in place.
       # @see #replace
       def compose(other, offset_x = 0, offset_y = 0)
         dup.compose!(other, offset_x, offset_y)
       end
-      
-      # Replaces pixels on this image by pixels from another pixels, on a given offset.
-      # This method will modify the current canvas.
+
+      # Replaces pixels on this image by pixels from another pixels, on a given
+      # offset. This method will modify the current canvas.
       #
-      # This will completely replace the pixels of the background image. If you want to blend
-      # them with semi-transparent pixels from the foreground image, see {#compose!}.
+      # This will completely replace the pixels of the background image. If you
+      # want to blend them with semi-transparent pixels from the foreground
+      # image, see {#compose!}.
       #
-      # @param [ChunkyPNG::Canvas] other The foreground canvas to get the pixels from.
+      # @param [ChunkyPNG::Canvas] other The foreground canvas to get the
+      #   pixels from.
       # @param [Integer] offset_x The x-offset to apply the new foreground on.
       # @param [Integer] offset_y The y-offset to apply the new foreground on.
-      # @return [ChunkyPNG::Canvas] Returns itself, but with the other canvas placed onto it.
-      # @raise [ChunkyPNG::OutOfBounds] when the other canvas doesn't fit on this one,
-      #     given the offset and size of the other canvas.
+      # @return [ChunkyPNG::Canvas] Returns itself, but with the other canvas
+      #   placed onto it.
+      # @raise [ChunkyPNG::OutOfBounds] when the other canvas doesn't fit on
+      #   this one, given the offset and size of the other canvas.
       # @see #compose!
       # @see #replace
       def replace!(other, offset_x = 0, offset_y = 0)
@@ -106,80 +114,93 @@ module ChunkyPNG
         self
       end
 
-      # Replaces pixels on this image by pixels from another pixels, on a given offset.
-      # This method will modify the current canvas.
+      # Replaces pixels on this image by pixels from another pixels, on a given
+      # offset. This method will modify the current canvas.
       #
-      # This will completely replace the pixels of the background image. If you want to blend
-      # them with semi-transparent pixels from the foreground image, see {#compose!}.
+      # This will completely replace the pixels of the background image. If you
+      # want to blend them with semi-transparent pixels from the foreground
+      # image, see {#compose!}.
       #
       # @param (see #replace!)
       # @return [ChunkyPNG::Canvas] Returns a new, combined canvas.
-      # @raise [ChunkyPNG::OutOfBounds] when the other canvas doesn't fit on this one,
-      #     given the offset and size of the other canvas.
+      # @raise [ChunkyPNG::OutOfBounds] when the other canvas doesn't fit on
+      #   this one, given the offset and size of the other canvas.
       #
-      # @note API changed since 1.0 - This method now no longer is in place, but returns
-      #     a new canvas and leaves the original intact. Use {#replace!} if you want to
-      #     replace pixels on the canvas in place.
-      # @see #compose 
+      # @note API changed since 1.0 - This method now no longer is in place,
+      #   but returns a new canvas and leaves the original intact. Use
+      #   {#replace!} if you want to replace pixels on the canvas in place.
+      # @see #compose
       def replace(other, offset_x = 0, offset_y = 0)
         dup.replace!(other, offset_x, offset_y)
       end
 
-      # Crops an image, given the coordinates and size of the image that needs to be cut out.
-      # This will leave the original image intact and return a new, cropped image with pixels
-      # copied from the original image.
+      # Crops an image, given the coordinates and size of the image that needs
+      # to be cut out. This will leave the original image intact and return a
+      # new, cropped image with pixels copied from the original image.
       #
-      # @param [Integer] x The x-coordinate of the top left corner of the image to be cropped.
-      # @param [Integer] y The y-coordinate of the top left corner of the image to be cropped.
+      # @param [Integer] x The x-coordinate of the top left corner of the image
+      #   to be cropped.
+      # @param [Integer] y The y-coordinate of the top left corner of the image
+      #   to be cropped.
       # @param [Integer] crop_width The width of the image to be cropped.
       # @param [Integer] crop_height The height of the image to be cropped.
       # @return [ChunkyPNG::Canvas] Returns the newly created cropped image.
-      # @raise [ChunkyPNG::OutOfBounds] when the crop dimensions plus the given coordinates 
-      #     are bigger then the original image.
+      # @raise [ChunkyPNG::OutOfBounds] when the crop dimensions plus the given
+      #   coordinates are bigger then the original image.
       def crop(x, y, crop_width, crop_height)
         dup.crop!(x, y, crop_width, crop_height)
       end
-      
-      # Crops an image, given the coordinates and size of the image that needs to be cut out.
+
+      # Crops an image, given the coordinates and size of the image that needs
+      # to be cut out.
       #
-      # This will change the size and content of the current canvas. Use {#crop} if you want to 
-      # have a new canvas returned instead, leaving the current canvas intact.
+      # This will change the size and content of the current canvas. Use
+      # {#crop} if you want to have a new canvas returned instead, leaving the
+      # current canvas intact.
       #
-      # @param [Integer] x The x-coordinate of the top left corner of the image to be cropped.
-      # @param [Integer] y The y-coordinate of the top left corner of the image to be cropped.
+      # @param [Integer] x The x-coordinate of the top left corner of the image
+      #   to be cropped.
+      # @param [Integer] y The y-coordinate of the top left corner of the image
+      #   to be cropped.
       # @param [Integer] crop_width The width of the image to be cropped.
       # @param [Integer] crop_height The height of the image to be cropped.
-      # @return [ChunkyPNG::Canvas] Returns itself, but cropped. 
-      # @raise [ChunkyPNG::OutOfBounds] when the crop dimensions plus the given coordinates 
-      #     are bigger then the original image.      
+      # @return [ChunkyPNG::Canvas] Returns itself, but cropped.
+      # @raise [ChunkyPNG::OutOfBounds] when the crop dimensions plus the given
+      #   coordinates are bigger then the original image.
       def crop!(x, y, crop_width, crop_height)
-        raise ChunkyPNG::OutOfBounds, "Original image width is too small!" if crop_width + x > width
-        raise ChunkyPNG::OutOfBounds, "Original image height is too small!" if crop_height + y > height
-        
+        if crop_width + x > width
+          raise ChunkyPNG::OutOfBounds, 'Original image width is too small!'
+        end
+        if crop_height + y > height
+          raise ChunkyPNG::OutOfBounds, 'Original image height is too small!'
+        end
+
         new_pixels = []
         for cy in 0...crop_height do
           new_pixels += pixels.slice((cy + y) * width + x, crop_width)
         end
         replace_canvas!(crop_width, crop_height, new_pixels)
       end
-      
+
       # Flips the image horizontally, leaving the original intact.
       #
-      # This will flip the image on its horizontal axis, e.g. pixels on the top will now
-      # be pixels on the bottom. Chaining this method twice will return the original canvas.
-      # This method will leave the original object intact and return a new canvas.
+      # This will flip the image on its horizontal axis, e.g. pixels on the top
+      # will now be pixels on the bottom. Chaining this method twice will
+      # return the original canvas. This method will leave the original object
+      # intact and return a new canvas.
       #
       # @return [ChunkyPNG::Canvas] The flipped image
       # @see #flip_horizontally!
       def flip_horizontally
         dup.flip_horizontally!
       end
-      
+
       # Flips the image horizontally in place.
       #
-      # This will flip the image on its horizontal axis, e.g. pixels on the top will now
-      # be pixels on the bottom. Chaining this method twice will return the original canvas.
-      # This method will leave the original object intact and return a new canvas.
+      # This will flip the image on its horizontal axis, e.g. pixels on the top
+      # will now be pixels on the bottom. Chaining this method twice will
+      # return the original canvas. This method will leave the original object
+      # intact and return a new canvas.
       #
       # @return [ChunkyPNG::Canvas] Itself, but flipped
       # @see #flip_horizontally
@@ -190,17 +211,18 @@ module ChunkyPNG
           replace_row!(other_y, row(y))
           replace_row!(y, other_row)
         end
-        return self
+        self
       end
-      
+
       alias_method :flip!, :flip_horizontally!
       alias_method :flip,  :flip_horizontally
-      
+
       # Flips the image vertically, leaving the original intact.
       #
-      # This will flip the image on its vertical axis, e.g. pixels on the left will now
-      # be pixels on the right. Chaining this method twice will return the original canvas.
-      # This method will leave the original object intact and return a new canvas.
+      # This will flip the image on its vertical axis, e.g. pixels on the left
+      # will now be pixels on the right. Chaining this method twice will return
+      # the original canvas. This method will leave the original object intact
+      # and return a new canvas.
       #
       # @return [ChunkyPNG::Canvas] The flipped image
       # @see #flip_vertically!
@@ -210,9 +232,10 @@ module ChunkyPNG
 
       # Flips the image vertically in place.
       #
-      # This will flip the image on its vertical axis, e.g. pixels on the left will now
-      # be pixels on the right. Chaining this method twice will return the original canvas.
-      # This method will leave the original object intact and return a new canvas.
+      # This will flip the image on its vertical axis, e.g. pixels on the left
+      # will now be pixels on the right. Chaining this method twice will return
+      # the original canvas. This method will leave the original object intact
+      # and return a new canvas.
       #
       # @return [ChunkyPNG::Canvas] Itself, but flipped
       # @see #flip_vertically
@@ -220,48 +243,49 @@ module ChunkyPNG
         for y in 0...height do
           replace_row!(y, row(y).reverse)
         end
-        return self
+        self
       end
-      
+
       alias_method :mirror!, :flip_vertically!
       alias_method :mirror,  :flip_vertically
 
       # Returns a new canvas instance that is rotated 90 degrees clockwise.
       #
-      # This method will return a new canvas and leaves the original intact. 
-      # See {#rotate_right!} for the in place version.
+      # This method will return a new canvas and leaves the original intact.
       #
       # @return [ChunkyPNG::Canvas] A clockwise-rotated copy.
+      # @see #rotate_right! for the in place version.
       def rotate_right
         dup.rotate_right!
       end
 
       # Rotates the image 90 degrees clockwise in place.
       #
-      # This method will change the current canvas. See {#rotate_right} for
-      # a version that leaves th current canvas intact
+      # This method will change the current canvas.
       #
       # @return [ChunkyPNG::Canvas] Itself, but rotated clockwise.
+      # @see #rotate_right for a version that leaves the current canvas intact
       def rotate_right!
         rotated = self.class.new(height, width)
         new_pixels = []
         0.upto(width - 1) { |i| new_pixels += column(i).reverse }
         replace_canvas!(height, width, new_pixels)
       end
-      
+
       alias_method :rotate_clockwise,  :rotate_right
       alias_method :rotate_clockwise!, :rotate_right!
-      
+
       # Returns an image that is rotated 90 degrees counter-clockwise.
       #
-      # This method will leave the original object intact and return a new canvas.
-      # See {#rotate_left!} for the in place version.
+      # This method will leave the original object intact and return a new
+      # canvas.
       #
       # @return [ChunkyPNG::Canvas] A rotated copy of itself.
+      # @see #rotate_left! for the in-place version.
       def rotate_left
         dup.rotate_left!
       end
-      
+
       # Rotates the image 90 degrees counter-clockwise in place.
       #
       # This method will change the original canvas. See {#rotate_left} for a
@@ -274,29 +298,32 @@ module ChunkyPNG
         (width - 1).downto(0) { |i| new_pixels += column(i) }
         replace_canvas!(height, width, new_pixels)
       end
-      
+
       alias_method :rotate_counter_clockwise,  :rotate_left
       alias_method :rotate_counter_clockwise!, :rotate_left!
-      
+
       # Rotates the image 180 degrees.
-      # This method will leave the original object intact and return a new canvas.
+      #
+      # This method will leave the original object intact and return a new
+      # canvas.
       #
       # @return [ChunkyPNG::Canvas] The rotated image.
       # @see #rotate_180!
       def rotate_180
         dup.rotate_180!
       end
-      
+
       # Rotates the image 180 degrees in place.
       #
       # @return [ChunkyPNG::Canvas] Itself, but rotated 180 degrees.
       # @see #rotate_180
       def rotate_180!
         pixels.reverse!
-        return self
+        self
       end
-      
-      # Trims the border around the image, presumed to be the color of the first pixel.
+
+      # Trims the border around the image, presumed to be the color of the
+      # first pixel.
       #
       # @param [Integer] border The color to attempt to trim.
       # @return [ChunkyPNG::Canvas] The trimmed image.
@@ -308,17 +335,18 @@ module ChunkyPNG
       # Trims the border around the image in place.
       #
       # @param [Integer] border The color to attempt to trim.
-      # @return [ChunkyPNG::Canvas] Returns itself, but with the border trimmed.
+      # @return [ChunkyPNG::Canvas] Returns itself, but with the border
+      #  trimmed.
       # @see #trim
       def trim!(border = pixels.first)
         x1 = [*0...width].index   { |c| column(c).uniq != [border] }
         x2 = [*0...width].rindex  { |c| column(c).uniq != [border] }
         y1 = [*0...height].index  { |r|    row(r).uniq != [border] }
         y2 = [*0...height].rindex { |r|    row(r).uniq != [border] }
-        
+
         crop! x1, y1, x2 - x1 + 1, y2 - y1 + 1
       end
-      
+
       # Draws a border around the image.
       #
       # @param [Integer] size The size of the border.
@@ -344,16 +372,23 @@ module ChunkyPNG
       end
 
       protected
-      
-      # Checks whether another image has the correct dimension to be used for an operation
-      # on the current image, given an offset coordinate to work with.
+
+      # Checks whether another image has the correct dimension to be used for
+      # an operation on the current image, given an offset coordinate to work
+      # with.
       # @param [ChunkyPNG::Canvas] other The other canvas
-      # @param [Integer] offset_x The x offset on which the other image will be applied.
-      # @param [Integer] offset_y The y offset on which the other image will be applied.
+      # @param [Integer] offset_x The x offset on which the other image will be
+      #   applied.
+      # @param [Integer] offset_y The y offset on which the other image will be
+      #   applied.
       # @raise [ChunkyPNG::OutOfBounds] when the other image doesn't fit.
       def check_size_constraints!(other, offset_x, offset_y)
-        raise ChunkyPNG::OutOfBounds, "Background image width is too small!"  if width  < other.width  + offset_x
-        raise ChunkyPNG::OutOfBounds, "Background image height is too small!" if height < other.height + offset_y
+        if width  < other.width  + offset_x
+          raise ChunkyPNG::OutOfBounds, 'Background image width is too small!'
+        end
+        if height < other.height + offset_y
+          raise ChunkyPNG::OutOfBounds, 'Background image height is too small!'
+        end
       end
     end
   end

--- a/lib/chunky_png/color.rb
+++ b/lib/chunky_png/color.rb
@@ -1,5 +1,5 @@
 module ChunkyPNG
-  
+
   # Factory method to return a color value, based on the arguments given.
   #
   # @overload Color(r, g, b, a)
@@ -12,15 +12,18 @@ module ChunkyPNG
   #
   # @overload Color(hex_value, opacity = nil)
   #   @param (see ChunkyPNG::Color.from_hex)
-  #   @return [Integer] The hex color value, with the opacity applied if one was given.
+  #   @return [Integer] The hex color value, with the opacity applied if one
+  #     was given.
   #
   # @overload Color(color_name, opacity = nil)
   #   @param (see ChunkyPNG::Color.html_color)
-  #   @return [Integer] The hex color value, with the opacity applied if one was given.
+  #   @return [Integer] The hex color value, with the opacity applied if one
+  #     was given.
   #
   # @overload Color(color_value, opacity = nil)
   #   @param [Integer, :to_i] The color value.
-  #   @return [Integer] The color value, with the opacity applied if one was given.
+  #   @return [Integer] The color value, with the opacity applied if one was
+  #     given.
   #
   # @return [Integer] The determined color value as RGBA integer.
   # @raise [ArgumentError] if the arguments weren't understood as a color.
@@ -54,7 +57,7 @@ module ChunkyPNG
 
     # @return [Integer] The maximum value of each color component.
     MAX = 0xff
-    
+
     # @private
     # @return [Regexp] The regexp to parse 3-digit hex color values.
     HEX3_COLOR_REGEXP  = /\A(?:#|0x)?([0-9a-f]{3})\z/i
@@ -66,7 +69,7 @@ module ChunkyPNG
     # @private
     # @return [Regexp] The regexp to parse named color values.
     HTML_COLOR_REGEXP = /^([a-z][a-z_ ]+[a-z])(?:\ ?\@\ ?(1\.0|0\.\d+))?$/i
-    
+
     ####################################################################
     # CONSTRUCTING COLOR VALUES
     ####################################################################
@@ -76,7 +79,8 @@ module ChunkyPNG
     # It supports color numbers, colors in hex notation and named HTML colors.
     #
     # @param [Integer, String] The color value.
-    # @return [Integer] The color value, with the opacity applied if one was given.
+    # @return [Integer] The color value, with the opacity applied if one was
+    #   given.
     def parse(source)
       return source if source.kind_of?(Integer)
       case source.to_s
@@ -107,14 +111,16 @@ module ChunkyPNG
     end
 
     # Creates a new color using a grayscale teint.
-    # @param [Integer] teint The grayscale teint (0-255), will be used as r, g, and b value.
+    # @param [Integer] teint The grayscale teint (0-255), will be used as r, g,
+    #   and b value.
     # @return [Integer] The newly constructed color value.
     def grayscale(teint)
       teint << 24 | teint << 16 | teint << 8 | 0xff
     end
 
     # Creates a new color using a grayscale teint and alpha value.
-    # @param [Integer] teint The grayscale teint (0-255), will be used as r, g, and b value.
+    # @param [Integer] teint The grayscale teint (0-255), will be used as r, g,
+    #   and b value.
     # @param [Integer] a The opacity (0-255)
     # @return [Integer] The newly constructed color value.
     def grayscale_alpha(teint, a)
@@ -127,7 +133,7 @@ module ChunkyPNG
 
     # Creates a color by unpacking an rgb triple from a string.
     #
-    # @param [String] stream The string to load the color from. It should be 
+    # @param [String] stream The string to load the color from. It should be
     #     at least 3 + pos bytes long.
     # @param [Integer] pos The position in the string to load the triple from.
     # @return [Integer] The newly constructed color value.
@@ -137,15 +143,15 @@ module ChunkyPNG
 
     # Creates a color by unpacking an rgba triple from a string
     #
-    # @param [String] stream The string to load the color from. It should be 
+    # @param [String] stream The string to load the color from. It should be
     #      at least 4 + pos bytes long.
     # @param [Integer] pos The position in the string to load the triple from.
     # @return [Integer] The newly constructed color value.
     def from_rgba_stream(stream, pos = 0)
       rgba(*stream.unpack("@#{pos}C4"))
     end
-    
-    # Creates a color by converting it from a string in hex notation. 
+
+    # Creates a color by converting it from a string in hex notation.
     #
     # It supports colors with (#rrggbbaa) or without (#rrggbb) alpha channel
     # as well as the 3-digit short format (#rgb) for those without.
@@ -181,7 +187,7 @@ module ChunkyPNG
     def r(value)
       (value & 0xff000000) >> 24
     end
-    
+
     # Returns the green-component from the color value.
     #
     # @param [Integer] value The color value.
@@ -189,7 +195,7 @@ module ChunkyPNG
     def g(value)
       (value & 0x00ff0000) >> 16
     end
-    
+
     # Returns the blue-component from the color value.
     #
     # @param [Integer] value The color value.
@@ -197,7 +203,7 @@ module ChunkyPNG
     def b(value)
       (value & 0x0000ff00) >> 8
     end
-    
+
     # Returns the alpha channel value for the color value.
     #
     # @param [Integer] value The color value.
@@ -205,7 +211,7 @@ module ChunkyPNG
     def a(value)
       value & 0x000000ff
     end
-    
+
     # Returns true if this color is fully opaque.
     #
     # @param [Integer] value The color to test.
@@ -213,14 +219,14 @@ module ChunkyPNG
     def opaque?(value)
       a(value) == 0x000000ff
     end
-    
+
     # Returns the opaque value of this color by removing the alpha channel.
     # @param [Integer] value The color to transform.
     # @return [Integer] The opaque color
     def opaque!(value)
       value | 0x000000ff
     end
-    
+
     # Returns true if this color is fully transparent.
     #
     # @param [Integer] value The color to test.
@@ -228,7 +234,7 @@ module ChunkyPNG
     def grayscale?(value)
       r(value) == b(value) && b(value) == g(value)
     end
-    
+
     # Returns true if this color is fully transparent.
     #
     # @param [Integer] value The color to test.
@@ -241,9 +247,9 @@ module ChunkyPNG
     # ALPHA COMPOSITION
     ####################################################################
 
-    # Multiplies two fractions using integer math, where the fractions are stored using an
-    # integer between 0 and 255. This method is used as a helper method for compositing
-    # colors using integer math.
+    # Multiplies two fractions using integer math, where the fractions are
+    # stored using an integer between 0 and 255. This method is used as a
+    # helper method for compositing colors using integer math.
     #
     # This is a quicker implementation of ((a * b) / 255.0).round.
     #
@@ -257,8 +263,8 @@ module ChunkyPNG
 
     # Composes two colors with an alpha channel using integer math.
     #
-    # This version is faster than the version based on floating point math, so this
-    # compositing function is used by default.
+    # This version is faster than the version based on floating point math, so
+    # this compositing function is used by default.
     #
     # @param [Integer] fg The foreground color.
     # @param [Integer] bg The foreground color.
@@ -267,7 +273,7 @@ module ChunkyPNG
     def compose_quick(fg, bg)
       return fg if opaque?(fg) || fully_transparent?(bg)
       return bg if fully_transparent?(fg)
-      
+
       a_com = int8_mult(0xff - a(fg), a(bg))
       new_r = int8_mult(a(fg), r(fg)) + int8_mult(a_com, r(bg))
       new_g = int8_mult(a(fg), g(fg)) + int8_mult(a_com, g(bg))
@@ -278,9 +284,9 @@ module ChunkyPNG
 
     # Composes two colors with an alpha channel using floating point math.
     #
-    # This method uses more precise floating point math, but this precision is lost
-    # when the result is converted back to an integer. Because it is slower than
-    # the version based on integer math, that version is preferred.
+    # This method uses more precise floating point math, but this precision is
+    # lost when the result is converted back to an integer. Because it is
+    # slower than the version based on integer math, that version is preferred.
     #
     # @param [Integer] fg The foreground color.
     # @param [Integer] bg The foreground color.
@@ -289,7 +295,7 @@ module ChunkyPNG
     def compose_precise(fg, bg)
       return fg if opaque?(fg) || fully_transparent?(bg)
       return bg if fully_transparent?(fg)
-      
+
       fg_a  = a(fg).to_f / MAX
       bg_a  = a(bg).to_f / MAX
       a_com = (1.0 - fg_a) * bg_a
@@ -302,8 +308,8 @@ module ChunkyPNG
     end
 
     alias :compose :compose_quick
-    
-    # Blends the foreground and background color by taking the average of 
+
+    # Blends the foreground and background color by taking the average of
     # the components.
     #
     # @param [Integer] fg The foreground color.
@@ -313,8 +319,8 @@ module ChunkyPNG
       (fg + bg) >> 1
     end
 
-    # Interpolates the foreground and background colors by the given alpha value.
-    # This also blends the alpha channels themselves.
+    # Interpolates the foreground and background colors by the given alpha
+    # value. This also blends the alpha channels themselves.
     #
     # A blending factor of 255 will give entirely the foreground,
     # while a blending factor of 0 will give the background.
@@ -326,37 +332,39 @@ module ChunkyPNG
     def interpolate_quick(fg, bg, alpha)
       return fg if alpha >= 255
       return bg if alpha <= 0
-      
+
       alpha_com = 255 - alpha
 
       new_r = int8_mult(alpha, r(fg)) + int8_mult(alpha_com, r(bg))
       new_g = int8_mult(alpha, g(fg)) + int8_mult(alpha_com, g(bg))
       new_b = int8_mult(alpha, b(fg)) + int8_mult(alpha_com, b(bg))
       new_a = int8_mult(alpha, a(fg)) + int8_mult(alpha_com, a(bg))
-      
-      return rgba(new_r, new_g, new_b, new_a)
+
+      rgba(new_r, new_g, new_b, new_a)
     end
 
     # Calculates the grayscale teint of an RGB color.
     #
-    # @param [Integer] color The color to convert.    
+    # @param [Integer] color The color to convert.
     # @return [Integer] The grayscale teint of the input color, 0-255.
     def grayscale_teint(color)
       (r(color) * 0.3 + g(color) * 0.59 + b(color) * 0.11).round
     end
-    
+
     # Converts a color to a fiting grayscale value. It will conserve the alpha
     # channel.
     #
-    # This method will return a full color value, with the R, G, and B value set
-    # to the grayscale teint calcuated from the input color's R, G and B values.
+    # This method will return a full color value, with the R, G, and B value
+    # set to the grayscale teint calcuated from the input color's R, G and B
+    # values.
     #
     # @param [Integer] color The color to convert.
-    # @return [Integer] The input color, converted to the best fitting grayscale.
+    # @return [Integer] The input color, converted to the best fitting
+    #   grayscale.
     # @see #grayscale_teint
     def to_grayscale(color)
       grayscale_alpha(grayscale_teint(color), a(color))
-    end    
+    end
 
     # Lowers the intensity of a color, by lowering its alpha by a given factor.
     # @param [Integer] color The color to adjust.
@@ -366,21 +374,23 @@ module ChunkyPNG
       new_alpha = int8_mult(a(color), factor)
       (color & 0xffffff00) | new_alpha
     end
-    
+
     # Decomposes a color, given a color, a mask color and a background color.
     # The returned color will be a variant of the mask color, with the alpha
-    # channel set to the best fitting value. This basically is the reverse 
+    # channel set to the best fitting value. This basically is the reverse
     # operation if alpha composition.
     #
     # If the color cannot be decomposed, this method will return the fully
     # transparent variant of the mask color.
     #
     # @param [Integer] color The color that was the result of compositing.
-    # @param [Integer] mask The opaque variant of the color that was being composed
+    # @param [Integer] mask The opaque variant of the color that was being
+    #   composed
     # @param [Integer] bg The background color on which the color was composed.
-    # @param [Integer] tolerance The decomposition tolerance level, a value between 0 and 255.
-    # @return [Integer] The decomposed color,a variant of the masked color with the 
-    #    alpha channel set to an appropriate value.
+    # @param [Integer] tolerance The decomposition tolerance level, a value
+    #   between 0 and 255.
+    # @return [Integer] The decomposed color, a variant of the masked color
+    #   with the alpha channel set to an appropriate value.
     def decompose_color(color, mask, bg, tolerance = 1)
       if alpha_decomposable?(color, mask, bg, tolerance)
         mask & 0xffffff00 | decompose_alpha(color, mask, bg)
@@ -388,62 +398,71 @@ module ChunkyPNG
         mask & 0xffffff00
       end
     end
-    
+
     # Checks whether an alpha channel value can successfully be composed
     # given the resulting color, the mask color and a background color,
-    # all of which should be opaque. 
+    # all of which should be opaque.
     #
     # @param [Integer] color The color that was the result of compositing.
-    # @param [Integer] mask The opaque variant of the color that was being composed
+    # @param [Integer] mask The opaque variant of the color that was being
+    #   composed
     # @param [Integer] bg The background color on which the color was composed.
-    # @param [Integer] tolerance The decomposition tolerance level, a value between 0 and 255.
-    # @return [Boolean] True if the alpha component can be decomposed successfully.
+    # @param [Integer] tolerance The decomposition tolerance level, a value
+    #   between 0 and 255.
+    # @return [Boolean] True if the alpha component can be decomposed
+    #   successfully.
     # @see #decompose_alpha
     def alpha_decomposable?(color, mask, bg, tolerance = 1)
       components = decompose_alpha_components(color, mask, bg)
-      sum = components.inject(0) { |a,b| a + b } 
+      sum = components.inject(0) { |a,b| a + b }
       max = components.max * 3
-      return components.max <= 255 && components.min >= 0 && (sum + tolerance * 3) >= max
+      components.max <= 255 && components.min >= 0 && (sum + tolerance * 3) >= max
     end
-    
-    # Decomposes the alpha channel value given the resulting color, the mask color 
-    # and a background color, all of which should be opaque.
+
+    # Decomposes the alpha channel value given the resulting color, the mask
+    # color and a background color, all of which should be opaque.
     #
-    # Make sure to call {#alpha_decomposable?} first to see if the alpha channel
-    # value can successfully decomposed with a given tolerance, otherwise the return 
-    # value of this method is undefined.
+    # Make sure to call {#alpha_decomposable?} first to see if the alpha
+    # channel value can successfully decomposed with a given tolerance,
+    # otherwise the return value of this method is undefined.
     #
     # @param [Integer] color The color that was the result of compositing.
-    # @param [Integer] mask The opaque variant of the color that was being composed
+    # @param [Integer] mask The opaque variant of the color that was being
+    #   composed
     # @param [Integer] bg The background color on which the color was composed.
-    # @return [Integer] The best fitting alpha channel, a value between 0 and 255.
+    # @return [Integer] The best fitting alpha channel, a value between 0 and
+    #   255.
     # @see #alpha_decomposable?
     def decompose_alpha(color, mask, bg)
       components = decompose_alpha_components(color, mask, bg)
       (components.inject(0) { |a,b| a + b } / 3.0).round
     end
-    
+
     # Decomposes an alpha channel for either the r, g or b color channel.
-    # @param [:r, :g, :b] channel The channel to decompose the alpha channel from.
+    # @param [:r, :g, :b] channel The channel to decompose the alpha channel
+    #   from.
     # @param [Integer] color The color that was the result of compositing.
-    # @param [Integer] mask The opaque variant of the color that was being composed
+    # @param [Integer] mask The opaque variant of the color that was being
+    #   composed
     # @param [Integer] bg The background color on which the color was composed.
     # @return [Integer] The decomposed alpha value for the channel.
     def decompose_alpha_component(channel, color, mask, bg)
       cc, mc, bc = send(channel, color), send(channel, mask), send(channel, bg)
-      
+
       return 0x00 if bc == cc
       return 0xff if bc == mc
       return 0xff if cc == mc
-      
+
       (((bc - cc).to_f / (bc - mc).to_f) * MAX).round
     end
-    
+
     # Decomposes the alpha channels for the r, g and b color channel.
     # @param [Integer] color The color that was the result of compositing.
-    # @param [Integer] mask The opaque variant of the color that was being composed
-    # @param [Integer] bg The background color on which the color was composed.    
-    # @return [Array<Integer>] The decomposed alpha values for the r, g and b channels.
+    # @param [Integer] mask The opaque variant of the color that was being
+    #   composed
+    # @param [Integer] bg The background color on which the color was composed.
+    # @return [Array<Integer>] The decomposed alpha values for the r, g and b
+    #   channels.
     def decompose_alpha_components(color, mask, bg)
       [
         decompose_alpha_component(:r, color, mask, bg),
@@ -456,7 +475,8 @@ module ChunkyPNG
     # CONVERSIONS
     ####################################################################
 
-    # Returns a string representing this color using hex notation (i.e. #rrggbbaa).
+    # Returns a string representing this color using hex notation (i.e.
+    # #rrggbbaa).
     #
     # @param [Integer] value The color to convert.
     # @return [String] The color in hex notation, starting with a pound sign.
@@ -472,8 +492,8 @@ module ChunkyPNG
       [r(color), g(color), b(color), a(color)]
     end
 
-    # Returns an array with the separate RGB values for this color.
-    # The alpha channel will be discarded.
+    # Returns an array with the separate RGB values for this color. The alpha
+    # channel will be discarded.
     #
     # @param [Integer] color The color to convert.
     # @return [Array<Integer>] An array with 3 Integer elements.
@@ -483,7 +503,7 @@ module ChunkyPNG
 
     # Returns an array with the grayscale teint value for this color.
     #
-    # This method expects the r,g and b value to be equal, and the alpha 
+    # This method expects the r, g, and b value to be equal, and the alpha
     # channel will be discarded.
     #
     # @param [Integer] color The grayscale color to convert.
@@ -492,16 +512,16 @@ module ChunkyPNG
       [b(color)] # assumption r == g == b
     end
 
-    # Returns an array with the grayscale teint and alpha channel values
-    # for this color.
+    # Returns an array with the grayscale teint and alpha channel values for
+    # this color.
     #
-    # This method expects the color to be grayscale, i.e. r,g and b value 
-    # to be equal and uses only the B channel. If you need to convert a 
-    # color to grayscale first, see {#to_grayscale}.
+    # This method expects the color to be grayscale, i.e. r, g, and b value to
+    # be equal and uses only the B channel. If you need to convert a color to
+    # grayscale first, see {#to_grayscale}.
     #
     # @param [Integer] color The grayscale color to convert.
     # @return [Array<Integer>] An array with 2 Integer elements.
-    # @see #to_grascale
+    # @see #to_grayscale
     def to_grayscale_alpha_bytes(color)
       [b(color), a(color)] # assumption r == g == b
     end
@@ -512,169 +532,169 @@ module ChunkyPNG
 
     # @return [Hash<Symbol, Integer>] All the predefined color names in HTML.
     PREDEFINED_COLORS = {
-      :aliceblue => 0xf0f8ff00,
-      :antiquewhite => 0xfaebd700,
-      :aqua => 0x00ffff00,
-      :aquamarine => 0x7fffd400,
-      :azure => 0xf0ffff00,
-      :beige => 0xf5f5dc00,
-      :bisque => 0xffe4c400,
-      :black => 0x00000000,
-      :blanchedalmond => 0xffebcd00,
-      :blue => 0x0000ff00,
-      :blueviolet => 0x8a2be200,
-      :brown => 0xa52a2a00,
-      :burlywood => 0xdeb88700,
-      :cadetblue => 0x5f9ea000,
-      :chartreuse => 0x7fff0000,
-      :chocolate => 0xd2691e00,
-      :coral => 0xff7f5000,
-      :cornflowerblue => 0x6495ed00,
-      :cornsilk => 0xfff8dc00,
-      :crimson => 0xdc143c00,
-      :cyan => 0x00ffff00,
-      :darkblue => 0x00008b00,
-      :darkcyan => 0x008b8b00,
-      :darkgoldenrod => 0xb8860b00,
-      :darkgray => 0xa9a9a900,
-      :darkgrey => 0xa9a9a900,
-      :darkgreen => 0x00640000,
-      :darkkhaki => 0xbdb76b00,
-      :darkmagenta => 0x8b008b00,
-      :darkolivegreen => 0x556b2f00,
-      :darkorange => 0xff8c0000,
-      :darkorchid => 0x9932cc00,
-      :darkred => 0x8b000000,
-      :darksalmon => 0xe9967a00,
-      :darkseagreen => 0x8fbc8f00,
-      :darkslateblue => 0x483d8b00,
-      :darkslategray => 0x2f4f4f00,
-      :darkslategrey => 0x2f4f4f00,
-      :darkturquoise => 0x00ced100,
-      :darkviolet => 0x9400d300,
-      :deeppink => 0xff149300,
-      :deepskyblue => 0x00bfff00,
-      :dimgray => 0x69696900,
-      :dimgrey => 0x69696900,
-      :dodgerblue => 0x1e90ff00,
-      :firebrick => 0xb2222200,
-      :floralwhite => 0xfffaf000,
-      :forestgreen => 0x228b2200,
-      :fuchsia => 0xff00ff00,
-      :gainsboro => 0xdcdcdc00,
-      :ghostwhite => 0xf8f8ff00,
-      :gold => 0xffd70000,
-      :goldenrod => 0xdaa52000,
-      :gray => 0x80808000,
-      :grey => 0x80808000,
-      :green => 0x00800000,
-      :greenyellow => 0xadff2f00,
-      :honeydew => 0xf0fff000,
-      :hotpink => 0xff69b400,
-      :indianred => 0xcd5c5c00,
-      :indigo => 0x4b008200,
-      :ivory => 0xfffff000,
-      :khaki => 0xf0e68c00,
-      :lavender => 0xe6e6fa00,
-      :lavenderblush => 0xfff0f500,
-      :lawngreen => 0x7cfc0000,
-      :lemonchiffon => 0xfffacd00,
-      :lightblue => 0xadd8e600,
-      :lightcoral => 0xf0808000,
-      :lightcyan => 0xe0ffff00,
+      :aliceblue            => 0xf0f8ff00,
+      :antiquewhite         => 0xfaebd700,
+      :aqua                 => 0x00ffff00,
+      :aquamarine           => 0x7fffd400,
+      :azure                => 0xf0ffff00,
+      :beige                => 0xf5f5dc00,
+      :bisque               => 0xffe4c400,
+      :black                => 0x00000000,
+      :blanchedalmond       => 0xffebcd00,
+      :blue                 => 0x0000ff00,
+      :blueviolet           => 0x8a2be200,
+      :brown                => 0xa52a2a00,
+      :burlywood            => 0xdeb88700,
+      :cadetblue            => 0x5f9ea000,
+      :chartreuse           => 0x7fff0000,
+      :chocolate            => 0xd2691e00,
+      :coral                => 0xff7f5000,
+      :cornflowerblue       => 0x6495ed00,
+      :cornsilk             => 0xfff8dc00,
+      :crimson              => 0xdc143c00,
+      :cyan                 => 0x00ffff00,
+      :darkblue             => 0x00008b00,
+      :darkcyan             => 0x008b8b00,
+      :darkgoldenrod        => 0xb8860b00,
+      :darkgray             => 0xa9a9a900,
+      :darkgrey             => 0xa9a9a900,
+      :darkgreen            => 0x00640000,
+      :darkkhaki            => 0xbdb76b00,
+      :darkmagenta          => 0x8b008b00,
+      :darkolivegreen       => 0x556b2f00,
+      :darkorange           => 0xff8c0000,
+      :darkorchid           => 0x9932cc00,
+      :darkred              => 0x8b000000,
+      :darksalmon           => 0xe9967a00,
+      :darkseagreen         => 0x8fbc8f00,
+      :darkslateblue        => 0x483d8b00,
+      :darkslategray        => 0x2f4f4f00,
+      :darkslategrey        => 0x2f4f4f00,
+      :darkturquoise        => 0x00ced100,
+      :darkviolet           => 0x9400d300,
+      :deeppink             => 0xff149300,
+      :deepskyblue          => 0x00bfff00,
+      :dimgray              => 0x69696900,
+      :dimgrey              => 0x69696900,
+      :dodgerblue           => 0x1e90ff00,
+      :firebrick            => 0xb2222200,
+      :floralwhite          => 0xfffaf000,
+      :forestgreen          => 0x228b2200,
+      :fuchsia              => 0xff00ff00,
+      :gainsboro            => 0xdcdcdc00,
+      :ghostwhite           => 0xf8f8ff00,
+      :gold                 => 0xffd70000,
+      :goldenrod            => 0xdaa52000,
+      :gray                 => 0x80808000,
+      :grey                 => 0x80808000,
+      :green                => 0x00800000,
+      :greenyellow          => 0xadff2f00,
+      :honeydew             => 0xf0fff000,
+      :hotpink              => 0xff69b400,
+      :indianred            => 0xcd5c5c00,
+      :indigo               => 0x4b008200,
+      :ivory                => 0xfffff000,
+      :khaki                => 0xf0e68c00,
+      :lavender             => 0xe6e6fa00,
+      :lavenderblush        => 0xfff0f500,
+      :lawngreen            => 0x7cfc0000,
+      :lemonchiffon         => 0xfffacd00,
+      :lightblue            => 0xadd8e600,
+      :lightcoral           => 0xf0808000,
+      :lightcyan            => 0xe0ffff00,
       :lightgoldenrodyellow => 0xfafad200,
-      :lightgray => 0xd3d3d300,
-      :lightgrey => 0xd3d3d300,
-      :lightgreen => 0x90ee9000,
-      :lightpink => 0xffb6c100,
-      :lightsalmon => 0xffa07a00,
-      :lightseagreen => 0x20b2aa00,
-      :lightskyblue => 0x87cefa00,
-      :lightslategray => 0x77889900,
-      :lightslategrey => 0x77889900,
-      :lightsteelblue => 0xb0c4de00,
-      :lightyellow => 0xffffe000,
-      :lime => 0x00ff0000,
-      :limegreen => 0x32cd3200,
-      :linen => 0xfaf0e600,
-      :magenta => 0xff00ff00,
-      :maroon => 0x80000000,
-      :mediumaquamarine => 0x66cdaa00,
-      :mediumblue => 0x0000cd00,
-      :mediumorchid => 0xba55d300,
-      :mediumpurple => 0x9370d800,
-      :mediumseagreen => 0x3cb37100,
-      :mediumslateblue => 0x7b68ee00,
-      :mediumspringgreen => 0x00fa9a00,
-      :mediumturquoise => 0x48d1cc00,
-      :mediumvioletred => 0xc7158500,
-      :midnightblue => 0x19197000,
-      :mintcream => 0xf5fffa00,
-      :mistyrose => 0xffe4e100,
-      :moccasin => 0xffe4b500,
-      :navajowhite => 0xffdead00,
-      :navy => 0x00008000,
-      :oldlace => 0xfdf5e600,
-      :olive => 0x80800000,
-      :olivedrab => 0x6b8e2300,
-      :orange => 0xffa50000,
-      :orangered => 0xff450000,
-      :orchid => 0xda70d600,
-      :palegoldenrod => 0xeee8aa00,
-      :palegreen => 0x98fb9800,
-      :paleturquoise => 0xafeeee00,
-      :palevioletred => 0xd8709300,
-      :papayawhip => 0xffefd500,
-      :peachpuff => 0xffdab900,
-      :peru => 0xcd853f00,
-      :pink => 0xffc0cb00,
-      :plum => 0xdda0dd00,
-      :powderblue => 0xb0e0e600,
-      :purple => 0x80008000,
-      :red => 0xff000000,
-      :rosybrown => 0xbc8f8f00,
-      :royalblue => 0x4169e100,
-      :saddlebrown => 0x8b451300,
-      :salmon => 0xfa807200,
-      :sandybrown => 0xf4a46000,
-      :seagreen => 0x2e8b5700,
-      :seashell => 0xfff5ee00,
-      :sienna => 0xa0522d00,
-      :silver => 0xc0c0c000,
-      :skyblue => 0x87ceeb00,
-      :slateblue => 0x6a5acd00,
-      :slategray => 0x70809000,
-      :slategrey => 0x70809000,
-      :snow => 0xfffafa00,
-      :springgreen => 0x00ff7f00,
-      :steelblue => 0x4682b400,
-      :tan => 0xd2b48c00,
-      :teal => 0x00808000,
-      :thistle => 0xd8bfd800,
-      :tomato => 0xff634700,
-      :turquoise => 0x40e0d000,
-      :violet => 0xee82ee00,
-      :wheat => 0xf5deb300,
-      :white => 0xffffff00,
-      :whitesmoke => 0xf5f5f500,
-      :yellow => 0xffff0000,
-      :yellowgreen => 0x9acd3200
+      :lightgray            => 0xd3d3d300,
+      :lightgrey            => 0xd3d3d300,
+      :lightgreen           => 0x90ee9000,
+      :lightpink            => 0xffb6c100,
+      :lightsalmon          => 0xffa07a00,
+      :lightseagreen        => 0x20b2aa00,
+      :lightskyblue         => 0x87cefa00,
+      :lightslategray       => 0x77889900,
+      :lightslategrey       => 0x77889900,
+      :lightsteelblue       => 0xb0c4de00,
+      :lightyellow          => 0xffffe000,
+      :lime                 => 0x00ff0000,
+      :limegreen            => 0x32cd3200,
+      :linen                => 0xfaf0e600,
+      :magenta              => 0xff00ff00,
+      :maroon               => 0x80000000,
+      :mediumaquamarine     => 0x66cdaa00,
+      :mediumblue           => 0x0000cd00,
+      :mediumorchid         => 0xba55d300,
+      :mediumpurple         => 0x9370d800,
+      :mediumseagreen       => 0x3cb37100,
+      :mediumslateblue      => 0x7b68ee00,
+      :mediumspringgreen    => 0x00fa9a00,
+      :mediumturquoise      => 0x48d1cc00,
+      :mediumvioletred      => 0xc7158500,
+      :midnightblue         => 0x19197000,
+      :mintcream            => 0xf5fffa00,
+      :mistyrose            => 0xffe4e100,
+      :moccasin             => 0xffe4b500,
+      :navajowhite          => 0xffdead00,
+      :navy                 => 0x00008000,
+      :oldlace              => 0xfdf5e600,
+      :olive                => 0x80800000,
+      :olivedrab            => 0x6b8e2300,
+      :orange               => 0xffa50000,
+      :orangered            => 0xff450000,
+      :orchid               => 0xda70d600,
+      :palegoldenrod        => 0xeee8aa00,
+      :palegreen            => 0x98fb9800,
+      :paleturquoise        => 0xafeeee00,
+      :palevioletred        => 0xd8709300,
+      :papayawhip           => 0xffefd500,
+      :peachpuff            => 0xffdab900,
+      :peru                 => 0xcd853f00,
+      :pink                 => 0xffc0cb00,
+      :plum                 => 0xdda0dd00,
+      :powderblue           => 0xb0e0e600,
+      :purple               => 0x80008000,
+      :red                  => 0xff000000,
+      :rosybrown            => 0xbc8f8f00,
+      :royalblue            => 0x4169e100,
+      :saddlebrown          => 0x8b451300,
+      :salmon               => 0xfa807200,
+      :sandybrown           => 0xf4a46000,
+      :seagreen             => 0x2e8b5700,
+      :seashell             => 0xfff5ee00,
+      :sienna               => 0xa0522d00,
+      :silver               => 0xc0c0c000,
+      :skyblue              => 0x87ceeb00,
+      :slateblue            => 0x6a5acd00,
+      :slategray            => 0x70809000,
+      :slategrey            => 0x70809000,
+      :snow                 => 0xfffafa00,
+      :springgreen          => 0x00ff7f00,
+      :steelblue            => 0x4682b400,
+      :tan                  => 0xd2b48c00,
+      :teal                 => 0x00808000,
+      :thistle              => 0xd8bfd800,
+      :tomato               => 0xff634700,
+      :turquoise            => 0x40e0d000,
+      :violet               => 0xee82ee00,
+      :wheat                => 0xf5deb300,
+      :white                => 0xffffff00,
+      :whitesmoke           => 0xf5f5f500,
+      :yellow               => 0xffff0000,
+      :yellowgreen          => 0x9acd3200
     }
-    
+
     # Gets a color value based on a HTML color name.
-    # 
-    # The color name is flexible. E.g. <tt>'yellowgreen'</tt>, <tt>'Yellow green'</tt>, 
-    # <tt>'YellowGreen'</tt>, <tt>'YELLOW_GREEN'</tt> and <tt>:yellow_green</tt> will
-    # all return the same color value.
     #
-    # You can include a opacity level in the color name (e.g. <tt>'red @ 0.5'</tt>) or give
-    # an explicit opacity value as second argument. If no opacity value is given, the color
-    # will be fully opaque.
+    # The color name is flexible. E.g. <tt>'yellowgreen'</tt>, <tt>'Yellow
+    # green'</tt>, <tt>'YellowGreen'</tt>, <tt>'YELLOW_GREEN'</tt> and
+    # <tt>:yellow_green</tt> will all return the same color value.
     #
-    # @param [Symbol, String] color_name The color name. It may include an opacity specifier
-    #   like <tt>@ 0.8</tt> to set the color's opacity.
-    # @param [Integer] opacity The opacity value for the color between 0 and 255. Overrides 
-    #   any opacity value given in the color name.
+    # You can include a opacity level in the color name (e.g. <tt>'red @
+    # 0.5'</tt>) or give an explicit opacity value as second argument. If no
+    # opacity value is given, the color will be fully opaque.
+    #
+    # @param [Symbol, String] color_name The color name. It may include an
+    #   opacity specifier like <tt>@ 0.8</tt> to set the color's opacity.
+    # @param [Integer] opacity The opacity value for the color between 0 and
+    #   255. Overrides any opacity value given in the color name.
     # @return [Integer] The color value.
     # @raise [ChunkyPNG::Exception] If the color name was not recognized.
     def html_color(color_name, opacity = nil)
@@ -713,33 +733,41 @@ module ChunkyPNG
       end
     end
 
-    # Returns the size in bytes of a pixel when it is stored using a given color mode.
-    # @param [Integer] color_mode The color mode in which the pixels are stored.
+    # Returns the size in bytes of a pixel when it is stored using a given
+    # color mode.
+    #
+    # @param [Integer] color_mode The color mode in which the pixels are
+    #   stored.
     # @return [Integer] The number of bytes used per pixel in a datastream.
     def pixel_bytesize(color_mode, depth = 8)
       return 1 if depth < 8
       (pixel_bitsize(color_mode, depth) + 7) >> 3
     end
-    
-    # Returns the size in bits of a pixel when it is stored using a given color mode.
-    # @param [Integer] color_mode The color mode in which the pixels are stored.
+
+    # Returns the size in bits of a pixel when it is stored using a given color
+    # mode.
+    #
+    # @param [Integer] color_mode The color mode in which the pixels are
+    #   stored.
     # @param [Integer] depth The color depth of the pixels.
     # @return [Integer] The number of bytes used per pixel in a datastream.
     def pixel_bitsize(color_mode, depth = 8)
       samples_per_pixel(color_mode) * depth
     end
-    
+
     # Returns the number of bytes used per scanline.
-    # @param [Integer] color_mode The color mode in which the pixels are stored.
+    # @param [Integer] color_mode The color mode in which the pixels are
+    #   stored.
     # @param [Integer] depth The color depth of the pixels.
     # @param [Integer] width The number of pixels per scanline.
     # @return [Integer] The number of bytes used per scanline in a datastream.
     def scanline_bytesize(color_mode, depth, width)
       ((pixel_bitsize(color_mode, depth) * width) + 7) >> 3
     end
-    
+
     # Returns the number of bytes used for an image pass
-    # @param [Integer] color_mode The color mode in which the pixels are stored.
+    # @param [Integer] color_mode The color mode in which the pixels are
+    #   stored.
     # @param [Integer] depth The color depth of the pixels.
     # @param [Integer] width The width of the image pass.
     # @param [Integer] width The height of the image pass.


### PR DESCRIPTION
This commit mostly wraps lines correctly. Among other changes are:
- Fixed some typos
- Aligned some code
- Removed unnecessary `return`s
- Converted some text in comments to YARD tags (@see)

All of these changes are intended to be cosmetic with the goal of
improving the readability of the code and documentation.

I only hit a few files in this commit, but I figured it was worth
committing anyway.
