### PR TITLE
Reformat YARD in Palette

### DIFF
--- a/lib/chunky_png/palette.rb
+++ b/lib/chunky_png/palette.rb
@@ -16,7 +16,7 @@ module ChunkyPNG
     # Builds a new palette given a set (Enumerable instance) of colors.
     #
     # @param enum [Enumerable<Integer>] The set of colors to include in this
-    #   palette.This Enumerable can contains duplicates.
+    #   palette.This Enumerable can contain duplicates.
     # @param decoding_map [Array] An array of colors in the exact order at
     #   which they appeared in the palette chunk, so that this array can be
     #   used for decoding.


### PR DESCRIPTION
This commit simply re-wraps the lines at 80 characters and moves the
variable names for the @param tags before the datatypes.
