### PR TITLE
Improve performance of Palette.from_canvas

### DIFF
--- a/lib/chunky_png/palette.rb
+++ b/lib/chunky_png/palette.rb
@@ -1,5 +1,4 @@
 module ChunkyPNG
-
   # A palette describes the set of colors that is being used for an image.
   #
   # A PNG image can contain an explicit palette which defines the colors of
@@ -12,7 +11,6 @@ module ChunkyPNG
   #
   # @see ChunkyPNG::Color
   class Palette < SortedSet
-
     # Builds a new palette given a set (Enumerable instance) of colors.
     #
     # @param enum [Enumerable<Integer>] The set of colors to include in this
@@ -56,7 +54,7 @@ module ChunkyPNG
         index += 1
       end
 
-      self.new(decoding_map, decoding_map)
+      new(decoding_map, decoding_map)
     end
 
     # Builds a palette instance from a given canvas.
@@ -66,7 +64,7 @@ module ChunkyPNG
       # Although we don't need to call .uniq.sort before initializing, because
       # Palette subclasses SortedSet, we get significantly better performance
       # by doing so.
-      self.new(canvas.pixels.uniq.sort)
+      new(canvas.pixels.uniq.sort)
     end
 
     # Builds a palette instance from a given set of pixels.
@@ -74,7 +72,7 @@ module ChunkyPNG
     #   palette for
     # @return [ChunkyPNG::Palette] The palette instance.
     def self.from_pixels(pixels)
-      self.new(pixels)
+      new(pixels)
     end
 
     # Checks whether the size of this palette is suitable for indexed storage.
@@ -217,11 +215,11 @@ module ChunkyPNG
     #   this image cannot be saved as an indexed image.
     def determine_bit_depth
       case size
-        when 1..2; 1
-        when 3..4; 2
-        when 5..16; 4
-        when 17..256; 8
-        else nil
+      when 1..2 then 1
+      when 3..4 then 2
+      when 5..16 then 4
+      when 17..256 then 8
+      else nil
       end
     end
   end


### PR DESCRIPTION
When saving a Canvas to a PNG file, we end up initializing an instance
of a Palette from the canvas pixels. Since the canvas pixels are stored
as an array, and Palette subclasses SortedSet, we end up with a
SortedSet of the unique colors in the Canvas.

While this works fine, I discovered that it could be a bit faster. After
some experimentation, it looks like if we first call `.uniq.sort` on the
pixel array before initializing the SortedSet, we can achieve some nice
performance wins with identical results. This was tested under Ruby
2.1.0.

For more context on the performance characteristics of this change, see:

  trotzig/diffux#76 (comment)
  trotzig/diffux#76 (comment)

We may also be able to use a similar technique in `.from_pixels`, but
since I am not aware of how that method is called and since it doesn't
benefit my current use-case, I am hesitant to make the same change there
at this time.
