### PR TITLE
Fix tags for Color#euclidean_distance_rgba

### DIFF
--- a/lib/chunky_png/color.rb
+++ b/lib/chunky_png/color.rb
@@ -540,8 +540,8 @@ module ChunkyPNG
     # Delta E in Lab colorspace, this method should serve many use-cases while
     # avoiding the overhead of converting RGBA to Lab.
     #
-    # @param color_a [Integer]
-    # @param color_b [Integer]
+    # @param pixel_after [Integer]
+    # @param pixel_before [Integer]
     # @return [Float]
     def euclidean_distance_rgba(pixel_after, pixel_before)
       Math.sqrt(


### PR DESCRIPTION
When I implemented this method, I accidentally left an older variable
name I was using in the YARD tags. Although these colors are
interchangeable due to the math involved (i.e. the before and after
aspect doesn't actually matter), the documentation should at least
reflect the actual code.
