### PR TITLE
Kernel#Array only casts - Array#new allows you to pass expected size.

### DIFF
--- a/lib/chunky_png/canvas/resampling.rb
+++ b/lib/chunky_png/canvas/resampling.rb
@@ -39,8 +39,8 @@ module ChunkyPNG
       # @param [Integer] new_width The width of the destination
       # @return [Array<Integer>, Array<Integer>] Two arrays of indicies and residues
       def steps_residues(width, new_width)
-        indicies = Array.new(size=new_width, obj=nil)
-        residues = Array.new(size=new_width, obj=nil)
+        indicies = Array.new(new_width, obj=nil)
+        residues = Array.new(new_width, obj=nil)
         
         # This works by accumulating the fractional error and
         # overflowing when necessary.
@@ -80,7 +80,7 @@ module ChunkyPNG
         steps_y = steps(height, new_height)
 
 
-        pixels = Array.new(size=new_width*new_height)
+        pixels = Array.new(new_width*new_height)
         i = 0
         for y in steps_y
           for x in steps_x
@@ -104,7 +104,7 @@ module ChunkyPNG
         index_x, interp_x = steps_residues(width, new_width)
         index_y, interp_y = steps_residues(height, new_height)
 
-        pixels = Array.new(size=new_width*new_height)
+        pixels = Array.new(new_width*new_height)
         i = 0
         for y in 1..new_height
           # Clamp the indicies to the edges of the image


### PR DESCRIPTION
You are probably calling the wrong method by mistake here. `Kernel#Array` doesn't take a `size` keyword argument - that's `Array#new`. You think you're allocating an array with a pre-allocated storage size, but you're just allocating an array `[size]`.
