### PR TITLE
Make crop much faster and take much less memory

### DIFF
--- a/lib/chunky_png/canvas/operations.rb
+++ b/lib/chunky_png/canvas/operations.rb
@@ -177,7 +177,7 @@ module ChunkyPNG
 
         new_pixels = []
         for cy in 0...crop_height do
-          new_pixels += pixels.slice((cy + y) * width + x, crop_width)
+          new_pixels.concat pixels.slice((cy + y) * width + x, crop_width)
         end
         replace_canvas!(crop_width, crop_height, new_pixels)
       end


### PR DESCRIPTION
The `+=` operation on array allocates a new array and copies everything on every pixel, which makes `crop`  very very slow. This little change of `concat` can speed up cropping a lot.

Here's the benchmark on a 1200x1200 image:

``` ruby
# bm.rb
require "chunky_png"
require "oily_png" # just make `.from_file` faster, no effect on `.crop`
png = ChunkyPNG::Image.from_file '1.png'
10.times {
  png.crop 0, 0, 600, 600
}
```

Before

``` sh
$ gtime -f "%e seconds, %M bytes" ruby bm.rb
8.65 seconds, 411205632 bytes
```

After

``` sh
$ gtime -f "%e seconds, %M bytes" ruby bm.rb
0.34 seconds, 286752768 bytes
```
