### PR TITLE
Fix Color#from_hsl, Color#from_hsv error when hue is 360

### DIFF
--- a/lib/chunky_png/color.rb
+++ b/lib/chunky_png/color.rb
@@ -256,7 +256,7 @@ module ChunkyPNG
       when (2...3); [0, chroma, x]
       when (3...4); [0, x, chroma]
       when (4...5); [x, 0, chroma]
-      when (5...6); [chroma, 0, x]
+      when (5..6);  [chroma, 0, x]
       end
     end
     private :cylindrical_to_cubic

--- a/spec/chunky_png/color_spec.rb
+++ b/spec/chunky_png/color_spec.rb
@@ -129,6 +129,10 @@ describe ChunkyPNG::Color do
 
       # And, finally, one random color
       expect(from_hsv(120, 0.5, 0.80)).to eql 0x66cc66ff
+
+      # Hue 0 and hue 360 should be equivalent
+      expect(from_hsv(0, 0.5, 0.5)).to eql from_hsv(360, 0.5, 0.5)
+      expect(from_hsv(0, 0.5, 0.5)).to eql from_hsv(360.0, 0.5, 0.5)
     end
 
     it 'should optionally accept a fourth param for alpha' do
@@ -162,6 +166,10 @@ describe ChunkyPNG::Color do
       from_hsl(87.27, 0.5, 0.5686)     == 0x96c85aff
       from_hsl(271.83, 0.5399, 0.4176) == 0x6e31a4ff
       from_hsl(63.6, 0.5984, 0.4882)   == 0xbec732ff
+
+      # Hue 0 and hue 360 should be equivalent
+      expect(from_hsl(0, 0.5, 0.5)).to eql from_hsl(360, 0.5, 0.5)
+      expect(from_hsl(0, 0.5, 0.5)).to eql from_hsl(360.0, 0.5, 0.5)
     end
 
     it 'should optionally accept a fourth param for alpha' do


### PR DESCRIPTION
Changing the private method `Color#cylindrical_to_cubic` to use an inclusive
rather than exclusive range fixes the NilClass error reported in Issue #85
without changing the public API.