### PR TITLE
Add spec for streams that are too short

### DIFF
--- a/lib/chunky_png/datastream.rb
+++ b/lib/chunky_png/datastream.rb
@@ -131,7 +131,7 @@ module ChunkyPNG
     def chunks
       enum_for(:each_chunk)
     end
-    
+
     # Returns all the textual metadata key/value pairs as hash.
     # @return [Hash] A hash containing metadata fields and their values.
     def metadata
@@ -141,7 +141,7 @@ module ChunkyPNG
       end
       metadata
     end
-   
+
     # Returns the uncompressed image data, combined from all the IDAT chunks
     # @return [String] The uncompressed image data for this datastream
     def imagedata

--- a/spec/chunky_png/datastream_spec.rb
+++ b/spec/chunky_png/datastream_spec.rb
@@ -5,12 +5,17 @@ describe ChunkyPNG::Datastream do
   describe '.from_io'do
     it "should raise an error when loading a file with a bad signature" do
       filename = resource_file('damaged_signature.png')
-      expect { ChunkyPNG::Datastream.from_file(filename) }.to raise_error
+      expect { ChunkyPNG::Datastream.from_file(filename) }.to raise_error(ChunkyPNG::SignatureMismatch)
     end
 
     it "should raise an error if the CRC of a chunk is incorrect" do
       filename = resource_file('damaged_chunk.png')
       expect { ChunkyPNG::Datastream.from_file(filename) }.to raise_error
+    end
+
+    it "should raise an error for a stream that is too short" do
+      stream = StringIO.new
+      expect { ChunkyPNG::Datastream.from_io(stream) }.to raise_error(ChunkyPNG::SignatureMismatch)
     end
   end
 


### PR DESCRIPTION
To make sure we're getting a useful error message.