### PR TITLE
Update rmagick.rb

### DIFF
--- a/lib/chunky_png/rmagick.rb
+++ b/lib/chunky_png/rmagick.rb
@@ -1,4 +1,4 @@
-require 'RMagick'
+require 'rmagick'
 
 module ChunkyPNG
   


### PR DESCRIPTION
Fixed Warning:[rake --prereqs] /usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-4.1.1/lib/active_support/values/time_zone.rb:285: warning: circular argument reference - now [DEPRECATION] requiring "RMagick" is deprecated. Use "rmagick" instead