### PR TITLE
Expect ChunkyPNG::CRCMismatch in datastream spec

### DIFF
--- a/spec/chunky_png/datastream_spec.rb
+++ b/spec/chunky_png/datastream_spec.rb
@@ -10,7 +10,7 @@ describe ChunkyPNG::Datastream do
 
     it "should raise an error if the CRC of a chunk is incorrect" do
       filename = resource_file('damaged_chunk.png')
-      expect { ChunkyPNG::Datastream.from_file(filename) }.to raise_error
+      expect { ChunkyPNG::Datastream.from_file(filename) }.to raise_error(ChunkyPNG::CRCMismatch)
     end
 
     it "should raise an error for a stream that is too short" do


### PR DESCRIPTION
When running RSpec, I noticed the following warning:

> WARNING: Using the `raise_error` matcher without providing a specific
> error or message risks false positives, since `raise_error` will match
> when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`,
> potentially allowing the expectation to pass without even executing
> the method you are intending to call. Instead consider providing a
> specific error class or message. This message can be supressed by
> setting:
> `RSpec::Expectations.configuration.warn_about_potential_false_positives
> = false`. Called from
> /path/to/chunky_png/spec/chunky_png/datastream_spec.rb:13:in `block
> (3 levels) in <top (required)>'.

I noticed that it was raising a `ChunkyPNG::CRCMismatch` error, so I
decided it would be best to just include that detail in the matcher.