### PR TITLE
Microoptimize ImageData.combine_chunks

### DIFF
--- a/lib/chunky_png/chunk.rb
+++ b/lib/chunky_png/chunk.rb
@@ -245,7 +245,11 @@ module ChunkyPNG
 
     class ImageData < Generic
       def self.combine_chunks(data_chunks)
-        Zlib::Inflate.inflate(data_chunks.map { |c| c.content }.join(''))
+        zstream = Zlib::Inflate.new
+        data_chunks.each { |c| zstream << c.content }
+        inflated = zstream.finish
+        zstream.close
+        inflated
       end
 
       def self.split_in_chunks(data, level = Zlib::DEFAULT_COMPRESSION, chunk_size = 2147483647)


### PR DESCRIPTION
When doing some memory profiling, I noticed that this line was
allocating by far the most memory in my application. Looking for a way
to bring this down a little, I discovered that we can avoid building and
joining our own array here by just pushing onto the stream directly.

Using memory_profiler in my application, this appears to bring memory
allocation down from 1,158,307,467 bytes (499,055 objects) to
1,154,056,455 bytes (498,849 objects), which is a difference of
4,251,012 bytes (roughly 4 MiB). While not the juicy win I'd really like
to see here, it seems like a simple enough change for the payoff.

I did see slightly worse memory usage for the smallest of images due to
the overhead of allocating the memory for instantiating the
Zlib::Inflate class, but I think this is a worthwhile tradeoff.