### PR TITLE
Added support for parsing the physical dimensions of a PNG’s pixels

### DIFF
--- a/lib/chunky_png.rb
+++ b/lib/chunky_png.rb
@@ -121,6 +121,11 @@ module ChunkyPNG
   class OutOfBounds < ChunkyPNG::ExpectationFailed
   end
 
+  # Exception that is raised when requesting the DPI of a PNG that doesn't
+  # specify the units of its physical pixel dimensions.
+  class UnitsUnknown < ChunkyPNG::Exception
+  end
+
   def self.force_binary(str)
     str.respond_to?(:force_encoding) ? str.force_encoding('BINARY') : str
   end

--- a/lib/chunky_png/chunk.rb
+++ b/lib/chunky_png/chunk.rb
@@ -327,7 +327,7 @@ module ChunkyPNG
     class Physical < Generic
       attr_accessor :ppux, :ppuy, :unit
 
-      def initialize(ppux, ppuy, unit=:unknown)
+      def initialize(ppux, ppuy, unit = :unknown)
         raise ArgumentError, 'unit must be either :meters or :unknown' unless [:meters, :unknown].member?(unit)
         super('pHYs')
         @ppux, @ppuy, @unit = ppux, ppuy, unit

--- a/lib/chunky_png/chunk.rb
+++ b/lib/chunky_png/chunk.rb
@@ -334,11 +334,13 @@ module ChunkyPNG
       end
 
       def dpix
-        ppux * INCHES_PER_METER if unit == :meters
+        raise ChunkyPNG::UnitsUnknown, 'the PNG specifies its physical aspect ratio, but does not specify the units of its pixels\' physical dimensions' unless unit == :meters
+        ppux * INCHES_PER_METER
       end
 
       def dpiy
-        ppuy * INCHES_PER_METER if unit == :meters
+        raise ChunkyPNG::UnitsUnknown, 'the PNG specifies its physical aspect ratio, but does not specify the units of its pixels\' physical dimensions' unless unit == :meters
+        ppuy * INCHES_PER_METER
       end
 
       def self.read(type, content)

--- a/lib/chunky_png/datastream.rb
+++ b/lib/chunky_png/datastream.rb
@@ -29,6 +29,10 @@ module ChunkyPNG
     # @return [ChunkyPNG::Chunk::Transparency]
     attr_accessor :transparency_chunk
 
+    # The chunk containing the physical dimensions of the PNG's pixels.
+    # @return [ChunkyPNG::Chunk::Physical]
+    attr_accessor :physical_chunk
+
     # The chunks that together compose the images pixel data.
     # @return [Array<ChunkyPNG::Chunk::ImageData>]
     attr_accessor :data_chunks
@@ -81,6 +85,7 @@ module ChunkyPNG
             when ChunkyPNG::Chunk::Palette;      ds.palette_chunk = chunk
             when ChunkyPNG::Chunk::Transparency; ds.transparency_chunk = chunk
             when ChunkyPNG::Chunk::ImageData;    ds.data_chunks << chunk
+            when ChunkyPNG::Chunk::Physical;     ds.physical_chunk = chunk
             when ChunkyPNG::Chunk::End;          ds.end_chunk = chunk
             else ds.other_chunks << chunk
           end

--- a/spec/chunky_png/datastream_spec.rb
+++ b/spec/chunky_png/datastream_spec.rb
@@ -45,8 +45,15 @@ describe ChunkyPNG::Datastream do
     it 'should load pHYs chunks correctly' do
       filename = resource_file('clock.png')
       ds = ChunkyPNG::Datastream.from_file(filename)
+      expect(ds.physical_chunk.unit).to eql :meters
       expect(ds.physical_chunk.dpix.round).to eql 72
       expect(ds.physical_chunk.dpiy.round).to eql 72
+    end
+
+    it 'should raise ChunkyPNG::UnitsUnknown if we request dpi but the units are unknown' do
+      physical_chunk = ChunkyPNG::Chunk::Physical.new(2835, 2835, :unknown)
+      expect{physical_chunk.dpix}.to raise_error(ChunkyPNG::UnitsUnknown)
+      expect{physical_chunk.dpiy}.to raise_error(ChunkyPNG::UnitsUnknown)
     end
   end
 end

--- a/spec/chunky_png/datastream_spec.rb
+++ b/spec/chunky_png/datastream_spec.rb
@@ -40,4 +40,13 @@ describe ChunkyPNG::Datastream do
       expect(ds.metadata['Copyright']).to eql "Copyright Willem van Schaik, Singapore 1995-96"
     end
   end
+
+  describe '#physical_chunk' do
+    it 'should load pHYs chunks correctly' do
+      filename = resource_file('clock.png')
+      ds = ChunkyPNG::Datastream.from_file(filename)
+      expect(ds.physical_chunk.dpix.round).to eql 72
+      expect(ds.physical_chunk.dpiy.round).to eql 72
+    end
+  end
 end


### PR DESCRIPTION
The [pHYs chunk](http://www.libpng.org/pub/png/spec/1.2/PNG-Chunks.html#C.pHYs) publishes the intended physical dimensions of a PNG's pixels — which gives us the image's DPI.