### PR TITLE
Include the physical chunk when enumerating chunks

### DIFF
--- a/lib/chunky_png/datastream.rb
+++ b/lib/chunky_png/datastream.rb
@@ -126,6 +126,7 @@ module ChunkyPNG
       other_chunks.each { |chunk| yield(chunk) }
       yield(palette_chunk)      if palette_chunk
       yield(transparency_chunk) if transparency_chunk
+      yield(physical_chunk)     if physical_chunk
       data_chunks.each  { |chunk| yield(chunk) }
       yield(end_chunk)
     end

--- a/spec/chunky_png/datastream_spec.rb
+++ b/spec/chunky_png/datastream_spec.rb
@@ -42,12 +42,14 @@ describe ChunkyPNG::Datastream do
   end
 
   describe '#physical_chunk' do
-    it 'should load pHYs chunks correctly' do
+    it 'should read and write pHYs chunks correctly' do
       filename = resource_file('clock.png')
       ds = ChunkyPNG::Datastream.from_file(filename)
       expect(ds.physical_chunk.unit).to eql :meters
       expect(ds.physical_chunk.dpix.round).to eql 72
       expect(ds.physical_chunk.dpiy.round).to eql 72
+      ds = ChunkyPNG::Datastream.from_blob(ds.to_blob)
+      expect(ds.physical_chunk).not_to be_nil
     end
 
     it 'should raise ChunkyPNG::UnitsUnknown if we request dpi but the units are unknown' do


### PR DESCRIPTION
When the physical chunk was pulled out as its own, accessible attribute of the datastream, it ceased to be included with `other_chunks`, and was therefore neither listed nor (more importantly) written out when outputting the datastream to another format.