### PR TITLE
Add support of non UTF-8 strings in InternationalText

### DIFF
--- a/lib/chunky_png/chunk.rb
+++ b/lib/chunky_png/chunk.rb
@@ -408,8 +408,10 @@ module ChunkyPNG
       # Assembles the content to write to the stream for this chunk.
       # @return [String] The binary content that should be written to the datastream.
       def content
-        text_field = (compressed == ChunkyPNG::COMPRESSED_CONTENT) ? Zlib::Deflate.deflate(text) : text
-        [keyword, compressed, compression, language_tag, translated_keyword, text_field].pack('Z*CCZ*Z*a*')
+        text_field = text.encode('utf-8')
+        text_field = (compressed == ChunkyPNG::COMPRESSED_CONTENT) ? Zlib::Deflate.deflate(text_field) : text_field
+
+        [keyword, compressed, compression, language_tag, translated_keyword.encode('utf-8'), text_field].pack('Z*CCZ*Z*a*')
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,10 +45,20 @@ module ResourceFileHelper
   end
 end
 
+module ChunkOperationsHelper
+
+  def serialized_chunk(chunk)
+    chunk.write(stream = StringIO.new)
+    stream.rewind
+    ChunkyPNG::Chunk.read(stream)
+  end
+end
+
 RSpec.configure do |config|
   config.extend PNGSuite
   config.include PNGSuite
   config.include ResourceFileHelper
+  config.include ChunkOperationsHelper
 
   config.expect_with :rspec do |c|
     c.syntax = [:should, :expect]


### PR DESCRIPTION
InternationalText text chunk could be accidentally created with non UTF-8 text or translated_keyword.
This PR adds encoding this fields to UTF-8 on write.