### PR TITLE
source_code_uri metadata

### DIFF
--- a/chunky_png.gemspec
+++ b/chunky_png.gemspec
@@ -35,6 +35,10 @@ Gem::Specification.new do |s|
   s.email    = ['willem@railsdoctors.com']
   s.homepage = 'https://github.com/wvanbergen/chunky_png/wiki'
   s.license  = 'MIT'
+  s.metadata = {
+    "source_code_uri"   => "https://github.com/wvanbergen/chunky_png",
+    "wiki_uri"          => "https://github.com/wvanbergen/chunky_png/wiki"
+  }
 
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec', '~> 3')

--- a/chunky_png.gemspec
+++ b/chunky_png.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
 
   s.authors  = ['Willem van Bergen']
   s.email    = ['willem@railsdoctors.com']
-  s.homepage = 'http://wiki.github.com/wvanbergen/chunky_png'
+  s.homepage = 'https://github.com/wvanbergen/chunky_png/wiki'
   s.license  = 'MIT'
 
   s.add_development_dependency('rake')


### PR DESCRIPTION
This PR both updates the homepage and specify the correct metadata for `source_code_uri`. 

Currently, it is very difficult for automated tools to figure out where to get the full source of the gem. In particular, libraries.io's has the wrong repository link for this gem, because there is no source_code_uri set on rubygems.org and because the fallback (homepage) isn't a format it recognizes.

Thanks
