### PR TITLE
Fix failing specs by implementing Dimension#hash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ script: bundle exec rake
 sudo: false
 
 rvm:
-- "2.0"
-- "2.1"
 - "2.2"
 - "2.3"
 - "2.4"
@@ -15,4 +13,3 @@ rvm:
 matrix:
   allow_failures:
   - rvm: ruby-head
-  - rvm: "2.5" # Broken on Travis on 2018-01-23

--- a/lib/chunky_png/dimension.rb
+++ b/lib/chunky_png/dimension.rb
@@ -107,6 +107,12 @@ module ChunkyPNG
 
     alias_method :==, :eql?
 
+    # Calculates a hash for the dimension object, based on width and height
+    # @return [Integer] A hashed value of the dimensions
+    def hash
+      [width, height].hash
+    end
+
     # Compares the size of 2 dimensions.
     # @param [ChunkyPNG::Dimension] The dimension to compare with.
     # @return [-1, 0, 1] -1 if the other dimension has a larger area, 1 of this


### PR DESCRIPTION
This makes sure all specs succeed again after the implementation of the change matcher in RSpec was updated to check for the hash of an object.