### PR TITLE
Drop unused Travis CI option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 script: bundle exec rake
-sudo: false
 
 rvm:
 - "2.2"


### PR DESCRIPTION
This PR removes an unused setting in the CI config.

See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration for historical detail about when it was removed.

