### PR TITLE
Avoid YARD warnings

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,5 +1,5 @@
 --title "ChunkyPNG - The pure Ruby PNG library"
 lib/**/*.rb -
-BENCHMARKS.rdoc
+BENCHMARKING.rdoc
 --no-private
 --hide-void-return

--- a/lib/chunky_png/canvas.rb
+++ b/lib/chunky_png/canvas.rb
@@ -68,7 +68,7 @@ module ChunkyPNG
     #   @param [Integer] height The height in pixels of this canvas
     #   @param [Integer, ...] background_color The initial background color of
     #     this canvas. This can be a color value or any value that
-    #     {ChunkyPNG::Color.parse} can handle.
+    #     {ChunkyPNG::Color#parse} can handle.
     #
     # @overload initialize(width, height, initial)
     #   @param [Integer] width The width in pixels of this canvas
@@ -143,7 +143,7 @@ module ChunkyPNG
     #
     # @param [Integer] x The x-coordinate of the pixel (column)
     # @param [Integer] y The y-coordinate of the pixel (row)
-    # @param [Integer] pixel The new color for the provided coordinates.
+    # @param [Integer] color The new color for the provided coordinates.
     # @return [Integer] The new color value for this pixel, i.e.
     #   <tt>color</tt>.
     def set_pixel(x, y, color)
@@ -155,7 +155,7 @@ module ChunkyPNG
     #
     # @param [Integer] x The x-coordinate of the pixel (column)
     # @param [Integer] y The y-coordinate of the pixel (row)
-    # @param [Integer] pixel The new color value for the provided coordinates.
+    # @param [Integer] color The new color value for the provided coordinates.
     # @return [Integer] The new color value for this pixel, i.e.
     #   <tt>color</tt>, or <tt>nil</tt> if the coordinates are out of bounds.
     def set_pixel_if_within_bounds(x, y, color)

--- a/lib/chunky_png/canvas/drawing.rb
+++ b/lib/chunky_png/canvas/drawing.rb
@@ -33,7 +33,8 @@ module ChunkyPNG
       end
 
       # Draws a Bezier curve
-      # @param [Array, Point] A collection of control points
+      # @param [Array, Point] points A collection of control points
+      # @param [Integer] stroke_color
       # @return [Chunky:PNG::Canvas] Itself, with the curve drawn
       def bezier_curve(points, stroke_color = ChunkyPNG::Color::BLACK)
         points = ChunkyPNG::Vector(*points)
@@ -162,7 +163,7 @@ module ChunkyPNG
       # Draws a polygon on the canvas using the stroke_color, filled using the
       # fill_color if any.
       #
-      # @param [Array, String] The control point vector. Accepts everything
+      # @param [Array, String] path The control point vector. Accepts everything
       #   {ChunkyPNG.Vector} accepts.
       # @param [Integer] stroke_color The stroke color to use for this polygon.
       # @param [Integer] fill_color The fill color to use for this polygon.

--- a/lib/chunky_png/canvas/operations.rb
+++ b/lib/chunky_png/canvas/operations.rb
@@ -15,8 +15,8 @@ module ChunkyPNG
       # the current instance intact, use {#grayscale} instead.
       #
       # @return [ChunkyPNG::Canvas] Returns itself, converted to grayscale.
-      # @see {#grayscale}
-      # @see {ChunkyPNG::Color#to_grayscale}
+      # @see #grayscale
+      # @see ChunkyPNG::Color#to_grayscale
       def grayscale!
         pixels.map! { |pixel| ChunkyPNG::Color.to_grayscale(pixel) }
         self
@@ -29,8 +29,8 @@ module ChunkyPNG
       #
       # @return [ChunkyPNG::Canvas] A copy of the canvas, converted to
       #   grayscale.
-      # @see {#grayscale!}
-      # @see {ChunkyPNG::Color#to_grayscale}
+      # @see #grayscale!
+      # @see ChunkyPNG::Color#to_grayscale
       def grayscale
         dup.grayscale!
       end

--- a/lib/chunky_png/canvas/png_decoding.rb
+++ b/lib/chunky_png/canvas/png_decoding.rb
@@ -85,7 +85,7 @@ module ChunkyPNG
       # color mode and interlacing mode.
       # @param [String] stream The pixelstream to read from.
       # @param [Integer] width The width of the image.
-      # @param [Integer] width The height of the image.
+      # @param [Integer] height The height of the image.
       # @param [Integer] color_mode The color mode of the encoded pixelstream.
       # @param [Integer] depth The bit depth of the pixel samples.
       # @param [Integer] interlace The interlace method of the encoded pixelstream.

--- a/lib/chunky_png/color.rb
+++ b/lib/chunky_png/color.rb
@@ -78,7 +78,7 @@ module ChunkyPNG
     #
     # It supports color numbers, colors in hex notation and named HTML colors.
     #
-    # @param [Integer, String] The color value.
+    # @param [Integer, String] source The color value.
     # @return [Integer] The color value, with the opacity applied if one was
     #   given.
     def parse(source)
@@ -157,8 +157,7 @@ module ChunkyPNG
     # as well as the 3-digit short format (#rgb) for those without.
     # Color strings may include the prefix "0x" or "#".
     #
-    # @param [String] str The color in hex notation. @return [Integer] The
-    #   converted color value.
+    # @param [String] hex_value The color in hex notation.
     # @param [Integer] opacity The opacity value for the color. Overrides any
     #    opacity value given in the hex value if given.
     # @return [Integer] The color value.
@@ -413,7 +412,7 @@ module ChunkyPNG
     # @param [Integer] fg The foreground color.
     # @param [Integer] bg The background color.
     # @param [Integer] alpha The blending factor (fixed 8bit)
-    # @param [Integer] The interpolated color.
+    # @return [Integer] The interpolated color.
     def interpolate_quick(fg, bg, alpha)
       return fg if alpha >= 255
       return bg if alpha <= 0
@@ -563,7 +562,8 @@ module ChunkyPNG
     # Returns a string representing this color using hex notation (i.e.
     # #rrggbbaa).
     #
-    # @param [Integer] value The color to convert.
+    # @param [Integer] color The color to convert.
+    # @param [Boolean] include_alpha
     # @return [String] The color in hex notation, starting with a pound sign.
     def to_hex(color, include_alpha = true)
       include_alpha ? ('#%08x' % color) : ('#%06x' % [color >> 8])
@@ -629,7 +629,7 @@ module ChunkyPNG
     # a ChunkPNG color. This logic is shared by the cylindrical HSV/HSB and HSL
     # color space models.
     #
-    # @param [Integer] A ChunkyPNG color.
+    # @param [Integer] color A ChunkyPNG color.
     # @return [Fixnum] hue The hue of the color (0-360)
     # @return [Fixnum] chroma The chroma of the color (0-1)
     # @return [Fixnum] max The magnitude of the largest scaled rgb component (0-1)
@@ -973,7 +973,7 @@ module ChunkyPNG
     #   stored.
     # @param [Integer] depth The color depth of the pixels.
     # @param [Integer] width The width of the image pass.
-    # @param [Integer] width The height of the image pass.
+    # @param [Integer] height The height of the image pass.
     # @return [Integer] The number of bytes used per scanline in a datastream.
     def pass_bytesize(color_mode, depth, width, height)
       return 0 if width == 0 || height == 0

--- a/lib/chunky_png/dimension.rb
+++ b/lib/chunky_png/dimension.rb
@@ -89,7 +89,7 @@ module ChunkyPNG
     end
 
     # Checks whether a point is within bounds of this dimension.
-    # @param [ChunkyPNG::Point, ...] A point-like to bounds-check.
+    # @param [ChunkyPNG::Point, ...] point_like A point-like to bounds-check.
     # @return [true, false] True iff the x and y coordinate fall in this dimension.
     # @see ChunkyPNG.Point
     def include?(*point_like)
@@ -98,7 +98,7 @@ module ChunkyPNG
     end
 
     # Checks whether 2 dimensions are identical.
-    # @param [ChunkyPNG::Dimension] The dimension to compare with.
+    # @param [ChunkyPNG::Dimension] other The dimension to compare with.
     # @return [true, false] <tt>true</tt> iff width and height match.
     def eql?(other)
       return false unless other.respond_to?(:width) && other.respond_to?(:height)
@@ -114,7 +114,7 @@ module ChunkyPNG
     end
 
     # Compares the size of 2 dimensions.
-    # @param [ChunkyPNG::Dimension] The dimension to compare with.
+    # @param [ChunkyPNG::Dimension] other The dimension to compare with.
     # @return [-1, 0, 1] -1 if the other dimension has a larger area, 1 of this
     #   dimension is larger, 0 if both are identical in size.
     def <=>(other)

--- a/lib/chunky_png/image.rb
+++ b/lib/chunky_png/image.rb
@@ -9,10 +9,10 @@ module ChunkyPNG
     # The minimum size of bytes the value of a metadata field should be before compression
     # is enabled for the chunk.
     METADATA_COMPRESSION_TRESHOLD = 300
-    
+
     # @return [Hash] The hash of metadata fields for this PNG image.
     attr_accessor :metadata
-    
+
     # Initializes a new ChunkyPNG::Image instance.
     # @param [Integer] width The width of the new image.
     # @param [Integer] height The height of the new image.
@@ -23,7 +23,7 @@ module ChunkyPNG
       super(width, height, bg_color)
       @metadata = metadata
     end
-    
+
     # Initializes a copy of another ChunkyPNG::Image instance.
     #
     # @param [ChunkyPNG::Image] other The other image to copy.
@@ -31,7 +31,7 @@ module ChunkyPNG
       super(other)
       @metadata = other.metadata
     end
-    
+
     # Returns the metadata for this image as PNG chunks.
     #
     # Chunks will either be of the {ChunkyPNG::Chunk::Text} type for small
@@ -49,7 +49,7 @@ module ChunkyPNG
         end
       end
     end
-    
+
     # Encodes the image to a PNG datastream for saving to disk or writing to an IO stream.
     #
     # Besides encoding the canvas, it will also encode the metadata fields to text chunks.
@@ -63,13 +63,13 @@ module ChunkyPNG
       ds.other_chunks += metadata_chunks
       return ds
     end
-    
+
     # Reads a ChunkyPNG::Image instance from a data stream.
     #
     # Besides decoding the canvas, this will also read the metadata fields
     # from the datastream.
     #
-    # @param [ChunkyPNG::Datastream] The datastream to read from.
+    # @param [ChunkyPNG::Datastream] ds The datastream to read from.
     def self.from_datastream(ds)
       image = super(ds)
       image.metadata = ds.metadata

--- a/lib/chunky_png/vector.rb
+++ b/lib/chunky_png/vector.rb
@@ -3,7 +3,7 @@ module ChunkyPNG
   # Factory method for {ChunkyPNG::Vector} instances.
   #
   # @overload Vector(x0, y0, x1, y1, x2, y2, ...)
-  #   Creates a vector by parsing two subsequent values in the argument list 
+  #   Creates a vector by parsing two subsequent values in the argument list
   #   as x- and y-coordinate of a point.
   #   @return [ChunkyPNG::Vector] The instantiated vector.
   # @overload Vector(string)
@@ -17,27 +17,27 @@ module ChunkyPNG
   # @raise [ArgumentError] If the given arguments could not be understood as a vector.
   # @see ChunkyPNG::Vector
   def self.Vector(*args)
-    
+
     return args.first if args.length == 1 && args.first.kind_of?(ChunkyPNG::Vector)
-    
+
     if args.length == 1 && args.first.respond_to?(:scan)
       ChunkyPNG::Vector.new(ChunkyPNG::Vector.multiple_from_string(args.first)) # e.g. ['1,1 2,2 3,3']
     else
       ChunkyPNG::Vector.new(ChunkyPNG::Vector.multiple_from_array(args)) # e.g. [[1,1], [2,2], [3,3]] or [1,1,2,2,3,3]
     end
   end
-  
+
   # Class that represents a vector of points, i.e. a list of {ChunkyPNG::Point} instances.
   #
-  # Vectors can be created quite flexibly. See the {ChunkyPNG.Vector} factory methods for 
+  # Vectors can be created quite flexibly. See the {ChunkyPNG.Vector} factory methods for
   # more information on how to construct vectors.
   class Vector
-    
+
     include Enumerable
-    
+
     # @return [Array<ChunkyPNG::Point>] The array that holds all the points in this vector.
     attr_reader :points
-    
+
     # Initializes a vector based on a list of Point instances.
     #
     # You usually do not want to use this method directly, but call {ChunkyPNG.Vector} instead.
@@ -47,7 +47,7 @@ module ChunkyPNG
     def initialize(points = [])
       @points = points
     end
-    
+
     # Iterates over all the edges in this vector.
     #
     # An edge is a combination of two subsequent points in the vector. Together, they will form
@@ -63,14 +63,14 @@ module ChunkyPNG
       points.each_cons(2) { |a, b| yield(a, b) }
       yield(points.last, points.first) if close
     end
-    
+
     # Returns the point with the given indexof this vector.
     # @param [Integer] index The 0-based index of the point in this vector.
-    # @param [ChunkyPNG::Point] The point instance.
+    # @return [ChunkyPNG::Point] The point instance.
     def [](index)
       points[index]
     end
-    
+
     # Returns an enumerator that will iterate over all the edges in this vector.
     # @param (see #each_edge)
     # @return [Enumerator] The enumerator that iterates over the edges.
@@ -79,27 +79,27 @@ module ChunkyPNG
     def edges(close = true)
       to_enum(:each_edge, close)
     end
-    
+
     # Returns the number of points in this vector.
     # @return [Integer] The length of the points array.
     def length
       points.length
     end
-    
+
     # Iterates over all the points in this vector
     # @yield [ChunkyPNG::Point] The points in the correct order.
     # @return [void]
     def each(&block)
       points.each(&block)
     end
-    
+
     # Comparison between two vectors for quality.
     # @param [ChunkyPNG::Vector] other The vector to compare with.
     # @return [true, false] true if the list of points are identical
     def eql?(other)
       other.points == points
     end
-    
+
     alias_method :==, :eql?
 
     # Returns the range in x-coordinates for all the points in this vector.
@@ -113,13 +113,13 @@ module ChunkyPNG
     def y_range
       Range.new(*points.map { |p| p.y }.minmax)
     end
-    
+
     # Finds the lowest x-coordinate in this vector.
     # @return [Integer] The lowest x-coordinate of all the points in the vector.
     def min_x
       x_range.first
     end
-    
+
     # Finds the highest x-coordinate in this vector.
     # @return [Integer] The highest x-coordinate of all the points in the vector.
     def max_x
@@ -131,13 +131,13 @@ module ChunkyPNG
     def min_y
       y_range.first
     end
-    
+
     # Finds the highest y-coordinate in this vector.
     # @return [Integer] The highest y-coordinate of all the points in the vector.
     def max_y
       y_range.last
     end
-    
+
     # Returns the offset from (0,0) of the minimal bounding box of all the
     # points in this vector
     # @return [ChunkyPNG::Point] A point that describes the top left corner if a
@@ -145,7 +145,7 @@ module ChunkyPNG
     def offset
       ChunkyPNG::Point.new(min_x, min_y)
     end
-    
+
     # Returns the width of the minimal bounding box of all the points in this vector.
     # @return [Integer] The x-distance between the points that are farthest from each other.
     def width
@@ -157,13 +157,13 @@ module ChunkyPNG
     def height
       1 + (max_y - min_y)
     end
-    
+
     # Returns the dimension of the minimal bounding rectangle of the points in this vector.
-    # @return [ChunkyPNG::Dimension] The dimension instance with the width and height 
+    # @return [ChunkyPNG::Dimension] The dimension instance with the width and height
     def dimension
       ChunkyPNG::Dimension.new(width, height)
     end
-    
+
     # @return [Array<ChunkyPNG::Point>] The list of points interpreted from the input array.
     def self.multiple_from_array(source)
       return [] if source.empty?
@@ -177,7 +177,7 @@ module ChunkyPNG
         source.map { |p| ChunkyPNG::Point(p) }
       end
     end
-    
+
     # @return [Array<ChunkyPNG::Point>] The list of points parsed from the string.
     def self.multiple_from_string(source_str)
       multiple_from_array(source_str.scan(/[\(\[\{]?(\d+)\s*[,x]?\s*(\d+)[\)\]\}]?/))


### PR DESCRIPTION
This PR fixes YARD warnings. Now, the API docs build without warnings.

- include the right file
- spell out some arguments
- fix spelling of some copy/paste mistakes
- avoid `{` and `}` for `@see` tags

