### PR TITLE
Remove more encoding helper methods; use Ruby’s built in encoding support instead

### DIFF
--- a/lib/chunky_png.rb
+++ b/lib/chunky_png.rb
@@ -140,20 +140,16 @@ module ChunkyPNG
   class UnitsUnknown < ChunkyPNG::Exception
   end
 
-  def self.force_binary(str)
-    str.respond_to?(:force_encoding) ? str.force_encoding('BINARY') : str
-  end
-
   # Empty byte array. This basically is an empty string, but with the encoding
   # set correctly to ASCII-8BIT (binary) in Ruby 1.9.
   # @return [String] An empty string, with encoding set to binary in Ruby 1.9
   # @private
-  EMPTY_BYTEARRAY = force_binary(String.new).freeze
+  EMPTY_BYTEARRAY = "".force_encoding(Encoding::BINARY).freeze
 
   # Null-byte, with the encoding set correctly to ASCII-8BIT (binary) in Ruby 1.9.
   # @return [String] A binary string, consisting of one NULL-byte.
   # @private
-  EXTRA_BYTE = force_binary(String.new("\0")).freeze
+  EXTRA_BYTE = "\0".force_encoding(Encoding::BINARY).freeze
 end
 
 require 'chunky_png/version'

--- a/lib/chunky_png/datastream.rb
+++ b/lib/chunky_png/datastream.rb
@@ -11,7 +11,7 @@ module ChunkyPNG
   class Datastream
 
     # The signature that each PNG file or stream should begin with.
-    SIGNATURE = ChunkyPNG.force_binary([137, 80, 78, 71, 13, 10, 26, 10].pack('C8'))
+    SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10].pack('C8').force_encoding(Encoding::BINARY).freeze
 
     # The header chunk of this datastream.
     # @return [ChunkyPNG::Chunk::Header]
@@ -57,7 +57,7 @@ module ChunkyPNG
       # @param [String] str The PNG encoded string to load from.
       # @return [ChunkyPNG::Datastream] The loaded datastream instance.
       def from_blob(str)
-        from_io(StringIO.new(str))
+        from_io(StringIO.new(str, 'rb'))
       end
 
       alias :from_string :from_blob
@@ -75,6 +75,7 @@ module ChunkyPNG
       # @param [IO] io The stream to read from.
       # @return [ChunkyPNG::Datastream] The loaded datastream instance.
       def from_io(io)
+        io.set_encoding(Encoding::BINARY)
         verify_signature!(io)
 
         ds = self.new
@@ -103,7 +104,7 @@ module ChunkyPNG
       #    the beginning of the stream.
       def verify_signature!(io)
         signature = io.read(ChunkyPNG::Datastream::SIGNATURE.length)
-        unless ChunkyPNG.force_binary(signature) == ChunkyPNG::Datastream::SIGNATURE
+        unless signature == ChunkyPNG::Datastream::SIGNATURE
           raise ChunkyPNG::SignatureMismatch, "PNG signature not found, found #{signature.inspect} instead of #{ChunkyPNG::Datastream::SIGNATURE.inspect}!"
         end
       end

--- a/spec/chunky_png/canvas/png_encoding_spec.rb
+++ b/spec/chunky_png/canvas/png_encoding_spec.rb
@@ -122,32 +122,32 @@ describe ChunkyPNG::Canvas::PNGEncoding do
 
     it "should encode using 8-bit RGBA mode correctly" do
       stream = @canvas.encode_png_pixelstream(ChunkyPNG::COLOR_TRUECOLOR_ALPHA, 8, ChunkyPNG::INTERLACING_NONE, ChunkyPNG::FILTER_NONE)
-      expect(stream).to eql ChunkyPNG.force_binary("\0\x01\x02\x03\x04\xFC\xFD\xFE\xFF\0\xFF\xFE\xFD\xFC\x04\x03\x02\x01")
+      expect(stream).to eql "\0\x01\x02\x03\x04\xFC\xFD\xFE\xFF\0\xFF\xFE\xFD\xFC\x04\x03\x02\x01".force_encoding(Encoding::BINARY)
     end
 
     it "should encode using 8 bit RGB mode correctly" do
       stream = @canvas.encode_png_pixelstream(ChunkyPNG::COLOR_TRUECOLOR, 8, ChunkyPNG::INTERLACING_NONE, ChunkyPNG::FILTER_NONE)
-      expect(stream).to eql ChunkyPNG.force_binary("\0\x01\x02\x03\xFC\xFD\xFE\0\xFF\xFE\xFD\x04\x03\x02")
+      expect(stream).to eql "\0\x01\x02\x03\xFC\xFD\xFE\0\xFF\xFE\xFD\x04\x03\x02".force_encoding(Encoding::BINARY)
     end
 
     it "should encode using 1-bit grayscale mode correctly" do
       stream = @canvas.encode_png_pixelstream(ChunkyPNG::COLOR_GRAYSCALE, 1, ChunkyPNG::INTERLACING_NONE, ChunkyPNG::FILTER_NONE)
-      expect(stream).to eql ChunkyPNG.force_binary("\0\x40\0\x80") # Using the B byte of the pixel == 3, assuming R == G == B for grayscale images
+      expect(stream).to eql "\0\x40\0\x80".force_encoding(Encoding::BINARY) # Using the B byte of the pixel == 3, assuming R == G == B for grayscale images
     end
 
     it "should encode using 2-bit grayscale mode correctly" do
       stream = @canvas.encode_png_pixelstream(ChunkyPNG::COLOR_GRAYSCALE, 2, ChunkyPNG::INTERLACING_NONE, ChunkyPNG::FILTER_NONE)
-      expect(stream).to eql ChunkyPNG.force_binary("\0\x30\0\xC0") # Using the B byte of the pixel == 3, assuming R == G == B for grayscale images
+      expect(stream).to eql "\0\x30\0\xC0".force_encoding(Encoding::BINARY) # Using the B byte of the pixel == 3, assuming R == G == B for grayscale images
     end
 
     it "should encode using 4-bit grayscale mode correctly" do
       stream = @canvas.encode_png_pixelstream(ChunkyPNG::COLOR_GRAYSCALE, 4, ChunkyPNG::INTERLACING_NONE, ChunkyPNG::FILTER_NONE)
-      expect(stream).to eql ChunkyPNG.force_binary("\0\x0F\0\xF0") # Using the B byte of the pixel == 3, assuming R == G == B for grayscale images
+      expect(stream).to eql "\0\x0F\0\xF0".force_encoding(Encoding::BINARY) # Using the B byte of the pixel == 3, assuming R == G == B for grayscale images
     end
 
     it "should encode using 8-bit grayscale mode correctly" do
       stream = @canvas.encode_png_pixelstream(ChunkyPNG::COLOR_GRAYSCALE, 8, ChunkyPNG::INTERLACING_NONE, ChunkyPNG::FILTER_NONE)
-      expect(stream).to eql ChunkyPNG.force_binary("\0\x03\xFE\0\xFD\x02") # Using the B byte of the pixel == 3, assuming R == G == B for grayscale images
+      expect(stream).to eql "\0\x03\xFE\0\xFD\x02".force_encoding(Encoding::BINARY) # Using the B byte of the pixel == 3, assuming R == G == B for grayscale images
     end
 
     it "should not encode using 1-bit indexed mode because the image has too many colors" do
@@ -158,17 +158,17 @@ describe ChunkyPNG::Canvas::PNGEncoding do
 
     it "should encode using 2-bit indexed mode correctly" do
       stream = @canvas.encode_png_pixelstream(ChunkyPNG::COLOR_INDEXED, 2, ChunkyPNG::INTERLACING_NONE, ChunkyPNG::FILTER_NONE)
-      expect(stream).to eql ChunkyPNG.force_binary("\0\x20\0\xD0")
+      expect(stream).to eql "\0\x20\0\xD0".force_encoding(Encoding::BINARY)
     end
 
     it "should encode using 4-bit indexed mode correctly" do
       stream = @canvas.encode_png_pixelstream(ChunkyPNG::COLOR_INDEXED, 4, ChunkyPNG::INTERLACING_NONE, ChunkyPNG::FILTER_NONE)
-      expect(stream).to eql ChunkyPNG.force_binary("\0\x02\0\x31")
+      expect(stream).to eql "\0\x02\0\x31".force_encoding(Encoding::BINARY)
     end
 
     it "should encode using 8-bit indexed mode correctly" do
       stream = @canvas.encode_png_pixelstream(ChunkyPNG::COLOR_INDEXED, 8, ChunkyPNG::INTERLACING_NONE, ChunkyPNG::FILTER_NONE)
-      expect(stream).to eql ChunkyPNG.force_binary("\0\x00\x02\0\x03\x01")
+      expect(stream).to eql "\0\x00\x02\0\x03\x01".force_encoding(Encoding::BINARY)
     end
   end
 


### PR DESCRIPTION
Follow up to #138. 