### PR TITLE
Better support for iTXt chunks that can be read/written as metadata

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -8,6 +8,7 @@ The file documents the changes to this library over the different versions.
 === Unreleased changes
 
 - Implemented <tt>ChunkyPNG::Dimension#hash</tt> to fix some specs after a behavior change in RSpec.
+- Better support for iTXt chunks that can be read/written as metadata
 
 === 1.3.11 - 2018-11-21
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ avatar.save('composited.png', :fast_rgba) # Force the fast saving routine.
 image = ChunkyPNG::Image.from_file('with_metadata.png')
 puts image.metadata['Title']
 image.metadata['Author'] = 'Willem van Bergen'
+image.metadata['custom_chunk'] = ChunkyPNG::Chunk::InternationalText.new('custom_chunk', "Hola!", "es")
 image.save('with_metadata.png') # Overwrite file
 
 # Low level access to PNG chunks

--- a/lib/chunky_png/chunk.rb
+++ b/lib/chunky_png/chunk.rb
@@ -69,6 +69,10 @@ module ChunkyPNG
         attributes.each { |k, v| send("#{k}=", v) }
       end
 
+      def ==(other)
+        content == other.content
+      end
+
       # Writes the chunk to the IO stream, using the provided content.
       # The checksum will be calculated and appended to the stream.
       # @param io [IO] The IO stream to write to.

--- a/lib/chunky_png/datastream.rb
+++ b/lib/chunky_png/datastream.rb
@@ -139,11 +139,10 @@ module ChunkyPNG
     # Returns all the textual metadata key/value pairs as hash.
     # @return [Hash] A hash containing metadata fields and their values.
     def metadata
-      metadata = {}
-      other_chunks.each do |chunk|
-        metadata[chunk.keyword] = chunk.value if chunk.respond_to?(:keyword) && chunk.respond_to?(:value)
+      other_chunks.each_with_object({}) do |chunk, hash|
+        hash[chunk.keyword] = chunk.value if chunk.respond_to?(:keyword) && chunk.respond_to?(:value)
+        hash[chunk.keyword] = chunk       if chunk.respond_to?(:keyword) && chunk.respond_to?(:text)
       end
-      metadata
     end
 
     # Returns the uncompressed image data, combined from all the IDAT chunks

--- a/lib/chunky_png/image.rb
+++ b/lib/chunky_png/image.rb
@@ -40,7 +40,9 @@ module ChunkyPNG
     # @see ChunkyPNG::Image::METADATA_COMPRESSION_TRESHOLD
     def metadata_chunks
       metadata.map do |key, value|
-        if value.length >= METADATA_COMPRESSION_TRESHOLD
+        if value.kind_of?(ChunkyPNG::Chunk::Base) # Add it directly - programmer _probably_ knows what he's doing...
+          value
+        elsif value.length >= METADATA_COMPRESSION_TRESHOLD
           ChunkyPNG::Chunk::CompressedText.new(key, value)
         else
           ChunkyPNG::Chunk::Text.new(key, value)

--- a/spec/chunky_png/datastream_spec.rb
+++ b/spec/chunky_png/datastream_spec.rb
@@ -39,10 +39,18 @@ describe ChunkyPNG::Datastream do
       expect(ds.metadata["Copyright"]).to eql "Copyright Willem van Schaik, Singapore 1995-96"
     end
 
-    it "ignores iTXt chunks" do
+    it "handles iTXt chunks specially" do
       filename = resource_file("itxt_chunk.png")
       ds = ChunkyPNG::Datastream.from_file(filename)
-      expect(ds.metadata).to be_empty
+      expect(ds.metadata).to eq({
+        "coach" => ChunkyPNG::Chunk::InternationalText.new(
+          "coach",
+          "US extracurricular sports teacher at a school (UK: PE teacher) lowest class on a passenger aircraft (UK: economy)",
+          "en-us",
+          "trainer",
+          ChunkyPNG::COMPRESSED_CONTENT,
+        )
+      })
     end
   end
 

--- a/spec/chunky_png/image_spec.rb
+++ b/spec/chunky_png/image_spec.rb
@@ -14,11 +14,13 @@ describe ChunkyPNG::Image do
       image = ChunkyPNG::Image.new(10, 10)
       image.metadata["Title"]  = "My amazing icon!"
       image.metadata["Author"] = "Willem van Bergen"
+      image.metadata["iTXt_fun"] = ChunkyPNG::Chunk::InternationalText.new("iTXt_fun", "Hola!", "es")
       image.save(filename)
 
       metadata = ChunkyPNG::Datastream.from_file(filename).metadata
-      expect(metadata["Title"]).to  eql "My amazing icon!"
-      expect(metadata["Author"]).to eql "Willem van Bergen"
+      expect(metadata["Title"]).to    eql "My amazing icon!"
+      expect(metadata["Author"]).to   eql "Willem van Bergen"
+      expect(metadata["iTXt_fun"]).to eq  ChunkyPNG::Chunk::InternationalText.new("iTXt_fun", "Hola!", "es")
     end
 
     it "should load empty images correctly" do


### PR DESCRIPTION
I need it to easily add iTXt chunks to bake OpenBadges (https://www.imsglobal.org/sites/default/files/Badges/OBv2p0Final/baking/index.html). 

Hope it'll help someone and I didn't break any backward compatibilities.

```ruby
image.metadata["iTXt_fun"] = ChunkyPNG::Chunk::InternationalText.new("iTXt_fun", "Hola!", "es")

expect(metadata["iTXt_fun"]).to eq ChunkyPNG::Chunk::InternationalText.new("iTXt_fun", "Hola!", "es")
```