### PR TITLE
Fix usage with --enable-frozen-string-literal Ruby option

### DIFF
--- a/lib/chunky_png.rb
+++ b/lib/chunky_png.rb
@@ -142,12 +142,12 @@ module ChunkyPNG
   # set correctly to ASCII-8BIT (binary) in Ruby 1.9.
   # @return [String] An empty string, with encoding set to binary in Ruby 1.9
   # @private
-  EMPTY_BYTEARRAY = "".force_encoding(::Encoding::BINARY).freeze
+  EMPTY_BYTEARRAY = String.new.force_encoding(::Encoding::BINARY).freeze
 
   # Null-byte, with the encoding set correctly to ASCII-8BIT (binary) in Ruby 1.9.
   # @return [String] A binary string, consisting of one NULL-byte.
   # @private
-  EXTRA_BYTE = "\0".force_encoding(::Encoding::BINARY).freeze
+  EXTRA_BYTE = String.new("\0").force_encoding(::Encoding::BINARY).freeze
 end
 
 require "chunky_png/version"


### PR DESCRIPTION
I originally fixed this in 444edce952d76a2eb1a9a7964da9ea403e4add0e,
but it was broken by bb62069e144e5dff3f3ee1f772f6b649758258c6.