### PR TITLE
Set required_ruby_version to >=2.0.0 in gemspec

### DIFF
--- a/chunky_png.gemspec
+++ b/chunky_png.gemspec
@@ -50,4 +50,6 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files`.split($/)
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
+
+  s.required_ruby_version = ">= 2.0.0"
 end


### PR DESCRIPTION
Starting with 84d187188ee360a2a971a0a60befae8974173402, chunky_png
uses String#b, which was added in Ruby 2.0.