### PR TITLE
Drop dependency on SortedSet

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7' ]
+        ruby: [ '2.5', '2.6', '2.7', 'ruby-head' ]
 
     steps:
     - uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,6 @@ platforms :jruby do
   gem "jruby-openssl"
 end
 
-platform :rbx do
-  gem "rubysl"
-end
-
 group :jekyll do
   gem "jekyll", "~> 3.3"
   gem "kramdown-parser-gfm"

--- a/lib/chunky_png/palette.rb
+++ b/lib/chunky_png/palette.rb
@@ -12,7 +12,7 @@ module ChunkyPNG
   # explicit palette (stores as PLTE & tRNS chunks in a PNG file).
   #
   # @see ChunkyPNG::Color
-  class Palette < SortedSet
+  class Palette < Set
     # Builds a new palette given a set (Enumerable instance) of colors.
     #
     # @param enum [Enumerable<Integer>] The set of colors to include in this
@@ -21,8 +21,10 @@ module ChunkyPNG
     #   which they appeared in the palette chunk, so that this array can be
     #   used for decoding.
     def initialize(enum, decoding_map = nil)
-      super(enum)
+      super(enum.sort.freeze)
       @decoding_map = decoding_map if decoding_map
+      @encoding_map = {}
+      freeze
     end
 
     # Builds a palette instance from a PLTE chunk and optionally a tRNS chunk
@@ -135,7 +137,7 @@ module ChunkyPNG
     # @return [true, false] True if a encoding map was built when this palette
     #   was loaded.
     def can_encode?
-      !@encoding_map.nil?
+      !@encoding_map.empty?
     end
 
     # Returns a color, given the position in the original palette chunk.
@@ -176,8 +178,8 @@ module ChunkyPNG
     # @return [ChunkyPNG::Chunk::Palette] The PLTE chunk.
     # @see ChunkyPNG::Palette#can_encode?
     def to_plte_chunk
-      @encoding_map = {}
-      colors        = []
+      @encoding_map.clear
+      colors = []
 
       each_with_index do |color, index|
         @encoding_map[color] = index


### PR DESCRIPTION
Alternative to https://github.com/wvanbergen/chunky_png/pull/153

Regular `Set`, since they are backed by a `Hash`, keep the insertion order.  From what I gathered the palette is built once, but is not mutated (I mean not added to, it has some internal mutation).

Based on this, I believe that we can initialize a `Set` with a sorted array, which should give us the same result than a `SortedSet`.

cc @wvanbergen @tenderlove @jeremy 