### PR TITLE
ruby3_2 fix: check if object responds to regex_match op

### DIFF
--- a/lib/chunky_png/vector.rb
+++ b/lib/chunky_png/vector.rb
@@ -166,7 +166,7 @@ module ChunkyPNG
     # @return [Array<ChunkyPNG::Point>] The list of points interpreted from the input array.
     def self.multiple_from_array(source)
       return [] if source.empty?
-      if source.first.is_a?(Numeric) || source.first =~ /^\d+$/
+      if source.first.is_a?(Numeric) || ( source.first.respond_to?(:=~) && source.first =~ /^\d+$/ )
         raise ArgumentError, "The points array is expected to have an even number of items!" if source.length % 2 != 0
 
         points = []


### PR DESCRIPTION
Maybe there is more clean solution, however anyway proposing the fix.

Object#=~ is already deprecated since ruby2.6 and will be removed from ruby3.2. As the result, Array no longer respond to =~ from ruby3.2, for example.

Check if the target object really respond to =~ .

Closes #168